### PR TITLE
Ensure `parseInt` is called with the correct radix.

### DIFF
--- a/bin/ember-template-recast.js
+++ b/bin/ember-template-recast.js
@@ -16,7 +16,7 @@ program
   .option(
     '-c, --cpus <count>',
     'determines the number of processes started.',
-    parseInt,
+    n => parseInt(n, 10),
     Math.max(os.cpus().length - 1, 1)
   )
   .option('-d, --dry', 'dry run: no changes are made to files', false)


### PR DESCRIPTION
Commander passes both the user specified value and the default value into the callback for `.option`. This means that we were calling `parseInt(<user value>, <cpu count - 1>)`.

When the system cpu count was higher than 4 (the number of cpus that the `concurrency` test specifies) the test would pass (which is why CI was passing), however on my MacBook Pro with only 4 cpus we run `parseInt('4', 3)` which results in `NaN` and therefore fails the `concurrency` test.

/cc @lennyburdette