### PR TITLE
Fix: Closing tags on block statements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ function wrapNode(node, parentNode, nearestNodeWithLoc, parseResult) {
       if (property === 'path' && node.type === 'BlockStatement') {
         let start = {
           line: node.loc.end.line,
-          column: node.loc.end.column - 1 - node.path.original.length,
+          column: node.loc.end.column - 2 - original.original.length,
         };
         parseResult.modifications.push({
           start,

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -96,6 +96,30 @@ QUnit.module('ember-template-recast', function() {
     );
   });
 
+  QUnit.test('rename block component from longer to shorter name', function(assert) {
+    let template = stripIndent`
+      {{#this-is-a-long-name
+        hello="world"
+      }}
+        <div data-foo='single quoted'>
+          </div>
+      {{/this-is-a-long-name}}{{someInlineComponent hello="world"}}`;
+
+    let ast = parse(template);
+    ast.body[0].path = builders.path('baz-derp');
+
+    assert.equal(
+      print(ast),
+      stripIndent`
+        {{#baz-derp
+          hello="world"
+        }}
+          <div data-foo='single quoted'>
+            </div>
+        {{/baz-derp}}{{someInlineComponent hello="world"}}`
+    );
+  });
+
   QUnit.test('rename element tagname', function(assert) {
     let template = stripIndent`
       <div data-foo='single quoted'>


### PR DESCRIPTION
Due to how the starting column was picked, when going from a longer
component name to a shorter one, the closing tag would get garbled.
Update code to use original name's length to determine start of mod.

Fixes #11.

Testing done:
- Validated that new test fails against old code and passes with new code.
- Ran recast against dummy template locally.