### PR TITLE
Fix: Improve handling of removed hash pairs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,13 @@ function linesFrom(string) {
   // split the strip up by \n or \r\n
   let lines = string.match(reLines);
 
+  // always insist on returning one line (since we always modify one line)
+  // otherwise, lines might disappear!
+  // (if it's whitespace-only after splicing in changes, we'll edit it out below)
+  if (lines.length === 1) {
+    return lines;
+  }
+
   // the split above always results in an extra empty line at the end remove it
   return lines.slice(0, -1);
 }
@@ -133,7 +140,7 @@ class ParseResult {
     this.source = linesFrom(template);
     this.modifications = [];
 
-    let ast = preprocess(template);
+    let ast = preprocess(template, { ignoreStandalone: true });
     this.ast = wrapNode(ast, null, ast, this);
   }
 
@@ -160,12 +167,32 @@ class ParseResult {
         let isLastLine = index === replacementLines.length - 1;
         let updatedLine = line;
 
-        if (isFirstLine && firstLineContents) {
-          updatedLine = firstLineContents.slice(0, start.column) + line;
+        // We check for a couple of common error cases that can be introduced by line replacement...
+        // 1) For one-line edits, if there is whitespace before and after the edited section
+        //   (usually due to a removed prop), trim the preceeding whitespace before the edit.
+        if (isFirstLine && isLastLine && firstLineContents && lastLineContents) {
+          const hasPreceedingWhitespace = firstLineContents.slice(0, start.column).match(/\S+\s+$/);
+          const hasTrailingWhitespace = lastLineContents.slice(end.column).match(/^\s+\S+/);
+
+          if (hasPreceedingWhitespace && hasTrailingWhitespace) {
+            // trimEnd() is as of Node 10, so we probably want to use replace() until Node < 10 is EOLd.
+            updatedLine = firstLineContents.slice(0, start.column).replace(/\s+$/, '') + line;
+          } else {
+            updatedLine = firstLineContents.slice(0, start.column) + line;
+          }
+          updatedLine += lastLineContents.slice(end.column);
+        } else {
+          if (isFirstLine && firstLineContents) {
+            updatedLine = firstLineContents.slice(0, start.column) + line;
+          }
+          if (isLastLine && lastLineContents) {
+            updatedLine += lastLineContents.slice(end.column);
+          }
         }
 
-        if (isLastLine && lastLineContents) {
-          updatedLine += lastLineContents.slice(end.column);
+        // 2) If the only thing that's left on this line is whitespace, and we made a change, remove it.
+        if (updatedLine.match(/\S/) === null && line !== updatedLine) {
+          return null;
         }
 
         return updatedLine;

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -368,6 +368,63 @@ QUnit.module('whitespace and removed hash pairs', function() {
       {{/hello-world}}`
     );
   });
+
+  QUnit.test('Whitespace properly collapsed when the removed prop is last', function(assert) {
+    let template = stripIndent`
+    {{#hello-world}}
+      {{#foo-bar prop="abc" yetAnotherProp="xyz" anotherProp=123}}
+        Hello!
+      {{/foo-bar}}
+    {{/hello-world}}`;
+    let { code } = transform(template, function(env) {
+      let { builders: b } = env.syntax;
+      return {
+        HashPair(ast) {
+          if (ast.key === 'anotherProp') {
+            return b.text('');
+          }
+          return ast;
+        },
+      };
+    });
+    assert.equal(
+      code,
+      stripIndent`
+      {{#hello-world}}
+        {{#foo-bar prop="abc" yetAnotherProp="xyz"}}
+          Hello!
+        {{/foo-bar}}
+      {{/hello-world}}`
+    );
+  });
+
+  QUnit.test(
+    'Whitespace properly collapsed when the removed prop is last and the contents of the tag are spaced',
+    function(assert) {
+      let template = stripIndent`
+      {{#hello-world}}
+        {{ foo-bar prop="abc" yetAnotherProp="xyz" anotherProp=123 }}
+      {{/hello-world}}`;
+      let { code } = transform(template, function(env) {
+        let { builders: b } = env.syntax;
+        return {
+          HashPair(ast) {
+            if (ast.key === 'anotherProp') {
+              return b.text('');
+            }
+            return ast;
+          },
+        };
+      });
+      assert.equal(
+        code,
+        stripIndent`
+        {{#hello-world}}
+          {{ foo-bar prop="abc" yetAnotherProp="xyz" }}
+        {{/hello-world}}`
+      );
+    }
+  );
 });
 
 QUnit.module('multi-line', function(hooks) {


### PR DESCRIPTION
- Ensure that linesFrom always returns one line, so one-line inline
changes don't cause lines to disappear.
- Add a couple of sanity checks around whitespace errors that may be
introduced by splicing in content. Specifically, if the line is empty
and we made a change, remove it; and if there is whitespace surrounding
our edit, trim the preceding whitespace away.
- Turns on Glimmer preprocess option to preserve more whitespace in
printed ASTs. (Currently passing in the prop is a no-op; depends on
Glimmer PR that's in review.)

NOTE: For `ignoreStandalone` to have any effect, [this Glimmer PR](https://github.com/glimmerjs/glimmer-vm/pull/871) needs to be merged and the version of `@glimmer/syntax` this package depends on needs to be bumped.