### PR TITLE
Fix: Adding hash pairs to empty hashes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,25 +99,27 @@ function wrapNode(node, parentNode, nearestNodeWithLoc, nearestNodeWithStableLoc
           },
           value: updatedValue,
         });
-      } else if (property === 'hash' && node.type === 'BlockStatement' && _isSynthetic(original)) {
+      } else if (
+        property === 'hash' &&
+        (node.type === 'BlockStatement' || node.type === 'MustacheStatement') &&
+        _isSynthetic(original)
+      ) {
         // Catches case where we try to replace an empty hash with a hash
         // that contains entries.
         const endOfPath = node.path.loc.end;
-        const hasBlockParams = node.program.blockParams.length > 0;
         parseResult.modifications.push({
           start: endOfPath,
           end: endOfPath,
-          value: ` ${_print(updatedValue)}${hasBlockParams ? ' ' : ''}`,
+          value: ` ${_print(updatedValue)}`,
         });
-      } else if (property === '0' && parentNode.type === 'Hash' && _isSynthetic(parentNode)) {
+      } else if (Array.isArray(node) && parentNode.type === 'Hash' && _isSynthetic(parentNode)) {
         // Catches case where we try to push a new hash pair on to a hash
         // that doesn't contain any entries.
         const endOfPath = nearestNodeWithStableLoc.path.loc.end;
-        const hasBlockParams = nearestNodeWithStableLoc.program.blockParams.length > 0;
         parseResult.modifications.push({
           start: endOfPath,
           end: endOfPath,
-          value: ` ${_print(updatedValue)}${hasBlockParams ? ' ' : ''}`,
+          value: ` ${_print(updatedValue)}`,
         });
       } else {
         parseResult.modifications.push({

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -304,8 +304,8 @@ QUnit.module('transform', () => {
     assert.equal(code, '{{wat-wat}}');
   });
 
-  QUnit.test('replacing empty hash pair works', function(assert) {
-    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}';
+  QUnit.test('replacing empty hash pair on BlockStatement works', function(assert) {
+    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}{{baz}}';
     let { code } = transform(template, env => {
       let { builders: b } = env.syntax;
       return {
@@ -315,11 +315,11 @@ QUnit.module('transform', () => {
       };
     });
 
-    assert.equal(code, '{{#foo-bar hello="world"}}Hi there!{{/foo-bar}}');
+    assert.equal(code, '{{#foo-bar hello="world"}}Hi there!{{/foo-bar}}{{baz}}');
   });
 
-  QUnit.test('pushing new item on to empty hash pair works', function(assert) {
-    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}';
+  QUnit.test('pushing new item on to empty hash pair on BlockStatement works', function(assert) {
+    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}{{baz}}';
     let { code } = transform(template, env => {
       let { builders: b } = env.syntax;
       return {
@@ -329,15 +329,15 @@ QUnit.module('transform', () => {
       };
     });
 
-    assert.equal(code, '{{#foo-bar hello="world"}}Hi there!{{/foo-bar}}');
+    assert.equal(code, '{{#foo-bar hello="world"}}Hi there!{{/foo-bar}}{{baz}}');
   });
 
-  // Recast seems to be really unhappy about trying to make multiple sequential changes
-  // to a particular hash set. For now, if you need to add multiple items on to an
+  // There's currently an issue trying to make multiple sequential changes
+  // to an empty hash set. For now, if you need to add multiple items on to an
   // empty hash pair, better to build a hash and set the hash property on the
   // parent BlockStatement.
   QUnit.todo('pushing multiple new items on to empty hash pair works', function(assert) {
-    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}';
+    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}{{baz}}';
     let { code } = transform(template, env => {
       let { builders: b } = env.syntax;
       return {
@@ -347,7 +347,68 @@ QUnit.module('transform', () => {
       };
     });
 
-    assert.equal(code, '{{#foo-bar hello="world" foo="bar"}}Hi there!{{/foo-bar}}');
+    assert.equal(code, '{{#foo-bar hello="world" foo="bar"}}Hi there!{{/foo-bar}}{{baz}}');
+  });
+
+  QUnit.test('replacing empty hash pair on a BlockStatement w/ block params works', function(
+    assert
+  ) {
+    let template = '{{#foo-bar as |a b c|}}Hi there!{{/foo-bar}}{{baz}}';
+    let { code } = transform(template, env => {
+      let { builders: b } = env.syntax;
+      return {
+        BlockStatement(ast) {
+          ast.hash = b.hash([b.pair('hello', b.string('world'))]);
+        },
+      };
+    });
+
+    assert.equal(code, '{{#foo-bar hello="world" as |a b c|}}Hi there!{{/foo-bar}}{{baz}}');
+  });
+
+  QUnit.test(
+    'pushing new item on an empty hash on a BlockStatement w/ block params works',
+    function(assert) {
+      let template = '{{#foo-bar as |a b c|}}Hi there!{{/foo-bar}}{{baz}}';
+      let { code } = transform(template, env => {
+        let { builders: b } = env.syntax;
+        return {
+          BlockStatement(ast) {
+            ast.hash.pairs.push(b.pair('hello', b.string('world')));
+          },
+        };
+      });
+
+      assert.equal(code, '{{#foo-bar hello="world" as |a b c|}}Hi there!{{/foo-bar}}{{baz}}');
+    }
+  );
+
+  QUnit.test('replacing empty hash pair on MustacheStatement works', function(assert) {
+    let template = '{{foo-bar}}{{#baz}}Hello!{{/baz}}';
+    let { code } = transform(template, env => {
+      let { builders: b } = env.syntax;
+      return {
+        MustacheStatement(ast) {
+          ast.hash = b.hash([b.pair('hello', b.string('world'))]);
+        },
+      };
+    });
+
+    assert.equal(code, '{{foo-bar hello="world"}}{{#baz}}Hello!{{/baz}}');
+  });
+
+  QUnit.test('pushing new item on to empty hash pair on MustacheStatement works', function(assert) {
+    let template = '{{foo-bar}}{{#baz}}Hello!{{/baz}}';
+    let { code } = transform(template, env => {
+      let { builders: b } = env.syntax;
+      return {
+        MustacheStatement(ast) {
+          ast.hash.pairs.push(b.pair('hello', b.string('world')));
+        },
+      };
+    });
+
+    assert.equal(code, '{{foo-bar hello="world"}}{{#baz}}Hello!{{/baz}}');
   });
 });
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -303,6 +303,52 @@ QUnit.module('transform', () => {
 
     assert.equal(code, '{{wat-wat}}');
   });
+
+  QUnit.test('replacing empty hash pair works', function(assert) {
+    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}';
+    let { code } = transform(template, env => {
+      let { builders: b } = env.syntax;
+      return {
+        BlockStatement(ast) {
+          ast.hash = b.hash([b.pair('hello', b.string('world'))]);
+        },
+      };
+    });
+
+    assert.equal(code, '{{#foo-bar hello="world"}}Hi there!{{/foo-bar}}');
+  });
+
+  QUnit.test('pushing new item on to empty hash pair works', function(assert) {
+    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}';
+    let { code } = transform(template, env => {
+      let { builders: b } = env.syntax;
+      return {
+        BlockStatement(ast) {
+          ast.hash.pairs.push(b.pair('hello', b.string('world')));
+        },
+      };
+    });
+
+    assert.equal(code, '{{#foo-bar hello="world"}}Hi there!{{/foo-bar}}');
+  });
+
+  // Recast seems to be really unhappy about trying to make multiple sequential changes
+  // to a particular hash set. For now, if you need to add multiple items on to an
+  // empty hash pair, better to build a hash and set the hash property on the
+  // parent BlockStatement.
+  QUnit.todo('pushing multiple new items on to empty hash pair works', function(assert) {
+    let template = '{{#foo-bar}}Hi there!{{/foo-bar}}';
+    let { code } = transform(template, env => {
+      let { builders: b } = env.syntax;
+      return {
+        BlockStatement(ast) {
+          ast.hash.pairs.push(b.pair('hello', b.string('world')), b.pair('foo', b.string('bar')));
+        },
+      };
+    });
+
+    assert.equal(code, '{{#foo-bar hello="world" foo="bar"}}Hi there!{{/foo-bar}}');
+  });
 });
 
 QUnit.module('whitespace and removed hash pairs', function() {


### PR DESCRIPTION
An empty hash doesn't have a location. So we need to look to the BlockStatement to determine where to add the new hash.

**Note:**
This implementation has an issue with trying to add multiple items to a hash pair, as demonstrated in the `todo` test added. This likely have to do with line 112. I can possibly do something like...

```
      } else if (parseInt(property) !== NaN && parentNode.type === 'Hash' && _isSynthetic(parentNode)) {
```

which gets closer, but ends up with duplicate property entries...

```
"{{#foo-bar hello=\"world\" hello=\"world\" foo=\"bar\"}}Hi there!{{/foo-bar}}"
```