### PR TITLE
Drop support for Node.js 6 and 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ jobs:
     - name: Node 8
       node_js: "8"
 
-    - name: Node 9
-      node_js: "9"
-
     - name: Node 10
       node_js: "10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ jobs:
       install: yarn install --no-lockfile --non-interactive
       script: yarn test
 
-    - name: Node 6
-      node_js: "6"
-
     - name: Node 8
       node_js: "8"
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "bin": "bin/ember-template-recast.js",
   "engines": {
-    "node": "6.* || 8.* || 9.* || >= 10"
+    "node": "8.* || 9.* || >= 10"
   },
   "scripts": {
     "lint:js": "eslint .",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "bin": "bin/ember-template-recast.js",
   "engines": {
-    "node": "8.* || 9.* || >= 10"
+    "node": "8.* || >= 10"
   },
   "scripts": {
     "lint:js": "eslint .",


### PR DESCRIPTION
This PR drops support for two outdated Node.js releases to unblock a few dependency updates. This should be considered a breaking change and would require a new major version release.