### PR TITLE
fix: guard against "no method on undefined" errors

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -37,7 +37,9 @@ const verboseLogger = {
     this.spinner = ora(message).start();
   },
   updateSpinner(message) {
-    this.spinner && this.spinner.text = message;
+    if (this.spinner) {
+      this.spinner.text = message;
+    }
   },
   stopSpinner(persistentMessage) {
     if (persistentMessage) {

--- a/src/runner.js
+++ b/src/runner.js
@@ -37,13 +37,13 @@ const verboseLogger = {
     this.spinner = ora(message).start();
   },
   updateSpinner(message) {
-    this.spinner.text = message;
+    this.spinner && this.spinner.text = message;
   },
   stopSpinner(persistentMessage) {
     if (persistentMessage) {
-      this.spinner.stopAndPersist(persistentMessage);
+      this.spinner && this.spinner.stopAndPersist(persistentMessage);
     } else {
-      this.spinner.stop();
+      this.spinner && this.spinner.stop();
     }
   },
 };


### PR DESCRIPTION
The `logger.stopSpinner();` call in the `catch` block throws an exception if the spinner doesn't exist yet. This obscures the real error.