### PR TITLE
fix: ignore gitignored files when using globs

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -180,7 +180,7 @@ function getAllFiles(paths) {
     return path;
   });
 
-  return globby(patterns, { absolute: true }).then(files => {
+  return globby(patterns, { absolute: true, gitignore: true }).then(files => {
     if (files.length < 1) {
       throw new NoFilesError();
     }


### PR DESCRIPTION
I couldn't run a codemod over my entire yarn workspace because `**/app/**/*.hbs` found some blueprint template files with ERB directives deep inside node_modules. They weren't valid handlebars and it blew up the process.