### PR TITLE
Ensure HTML Entities are not processed / modified.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ function wrapNode(node, parentNode, nearestNodeWithLoc, nearestNodeWithStableLoc
         parseResult.modifications.push({
           start: endOfPath,
           end: endOfPath,
-          value: ` ${_print(updatedValue)}`,
+          value: ` ${_print(updatedValue, { entityEncoding: 'raw' })}`,
         });
       } else if (Array.isArray(node) && parentNode.type === 'Hash' && _isSynthetic(parentNode)) {
         // Catches case where we try to push a new hash pair on to a hash
@@ -121,7 +121,7 @@ function wrapNode(node, parentNode, nearestNodeWithLoc, nearestNodeWithStableLoc
         parseResult.modifications.push({
           start: endOfPath,
           end: endOfPath,
-          value: ` ${_print(updatedValue)}`,
+          value: ` ${_print(updatedValue, { entityEncoding: 'raw' })}`,
         });
       } else {
         parseResult.modifications.push({
@@ -172,6 +172,7 @@ class ParseResult {
     this.modifications = [];
 
     let ast = preprocess(template, {
+      mode: 'codemod',
       parseOptions: {
         ignoreStandalone: true,
       },
@@ -188,7 +189,7 @@ class ParseResult {
       .reverse();
 
     sortedModifications.forEach(({ start, end, value }) => {
-      let printed = typeof value === 'string' ? value : _print(value);
+      let printed = typeof value === 'string' ? value : _print(value, { entityEncoding: 'raw' });
       let firstIndexToUpdate = start.line - 1;
       let lastIndexToUpdate = end.line - 1;
       let firstLineContents = this.source[firstIndexToUpdate];

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -52,6 +52,14 @@ QUnit.module('ember-template-recast', function() {
     );
   });
 
+  QUnit.test('basic parse -> mutation -> print: preserves HTML entities', function(assert) {
+    let template = stripIndent`<div>&nbsp;</div>`;
+    let ast = parse(template);
+    ast.body[0].children.push(builders.text('derp&nbsp;'));
+
+    assert.equal(print(ast), stripIndent`<div>&nbsp;derp&nbsp;</div>`);
+  });
+
   QUnit.test('rename non-block component', function(assert) {
     let template = stripIndent`
       {{foo-bar


### PR DESCRIPTION
Leverages the changes made in https://github.com/glimmerjs/glimmer-vm/pull/938 to avoid parsing/processing HTML entities.

Fixes #10