### PR TITLE
Add putout code transformer to lint

### DIFF
--- a/.putout.json
+++ b/.putout.json
@@ -1,0 +1,10 @@
+{
+    "match": {
+        "src/runner.js": {
+            "remove-console": false
+        }
+    },
+    "rules": {
+        "strict-mode": false
+    }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
   "bin": "bin/ember-template-recast.js",
   "scripts": {
     "changelog": "lerna-changelog",
+    "lint": "npm run lint:putout && npm run lint:js",
     "lint:js": "eslint .",
+    "lint:putout": "putout bin src",
+    "fix:lint:js": "npm run lint:js -- --fix",
+    "fix:lint:putout": "putout bin src --fix",
+    "fix:lint": "npm run fix:lint:putout && npm run fix:lint:js",
     "release": "release-it",
     "test": "qunit tests/**/*-test.js"
   },
@@ -35,6 +40,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "lerna-changelog": "^0.8.2",
     "prettier": "^1.18.2",
+    "putout": "^4.52.1",
     "qunit": "^2.9.2",
     "release-it": "^12.2.1",
     "release-it-lerna-changelog": "^1.0.3"

--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ class ParseResult {
       .sort((a, b) => a.start.line - b.start.line || a.start.column - b.start.column)
       .reverse();
 
-    sortedModifications.forEach(({ start, end, value }) => {
+    for (const { start, end, value } of sortedModifications) {
       let printed = typeof value === 'string' ? value : _print(value, { entityEncoding: 'raw' });
       let firstIndexToUpdate = start.line - 1;
       let lastIndexToUpdate = end.line - 1;
@@ -262,7 +262,7 @@ class ParseResult {
         1 /* always replace at least one line */ + lastIndexToUpdate - firstIndexToUpdate,
         ...mergedReplacementLines
       );
-    });
+    }
   }
 
   print() {

--- a/src/runner.js
+++ b/src/runner.js
@@ -93,10 +93,10 @@ class StatsCollector {
     if (this.errors.length) {
       this.logger.info(`Errored:   ${this.errors.length}`);
 
-      this.errors.slice(0, 5).forEach(({ file, error }) => {
+      for (const { file, error } of this.errors.slice(0, 5)) {
         this.logger.error(`${file}`);
         handleError(error, this.logger);
-      });
+      }
 
       if (this.errors.length > 5) {
         const more = this.errors.length - 5;


### PR DESCRIPTION
Hi, very nice parser 🙂. I like the way you made [plugin architecture](https://github.com/ember-template-lint/ember-template-recast#command-line-usage). I have a similar project: code transformer [putout](https://github.com/coderaiser/putout), it has a similar plugin api, but [a little bit simpler](https://github.com/coderaiser/putout#example):

```js
module.exports.traverse = ({push}) => {
    return {
        DebuggerStatement(path) {
            push(path);
        }
    }
};
```

No `traverse`, and `parse`. All of this [made in core](https://github.com/coderaiser/putout/blob/master/packages/putout/lib/putout.js#L60-L75) in a `putout`. And I would like to know, why you do it not in core, and put it in `plugin`, this functions should be called any way in every plugin and every plugin should `parse source code` again and again. Or you have only 1 running plugin in a same time support?

Also I want to suggest you using code transformer and linter `Putout`, which is not only suggest you to remove or convert something, but can [handle it by itself](https://github.com/coderaiser/putout#built-in-transforms) (from your permission of corse).

In a pull request you can find using result of a command `npm run fix:lint` with a `fix` of `putout`, it has changed `forEach` to `for-of` with a rule [convert-for-each-to-for-of](https://github.com/coderaiser/putout/tree/master/packages/plugin-convert-for-each-to-for-of).

You have a very good quality of a codebase, all `putout` rules is enabled by default, and you have only a couple possible transformations 🙂

Provided `.putout.json` contains information about excluding rule `remove-console` for `src/runner.js` (you use it for `logs`) and disabling rule `strict-mode`, because it looks like you don’t use it for a reason.