### PR TITLE
Remove duplicated @glimmer/syntax printer implementation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "qunit tests/**/*-test.js"
   },
   "dependencies": {
-    "@glimmer/syntax": "^0.41.3",
+    "@glimmer/syntax": "^0.41.4",
     "async-promise-queue": "^1.0.5",
     "colors": "^1.3.3",
     "commander": "^2.20.0",

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -1,30 +1,11 @@
 const { preprocess, print: _print } = require('@glimmer/syntax');
-const { sortByLoc, compactJoin } = require('./utils');
+const { sortByLoc } = require('./utils');
 
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const leadingWhitespace = /(^\s+)/;
 const trailingWhitespace = /(\s+)$/;
 const attrNodeParts = /(^[^=]+)(\s+)?(=)?(\s+)?(\S+)?/;
 const hashPairParts = /(^[^=]+)(\s+)?=(\s+)?(\S+)/;
-
-const voidElements = new Set([
-  'area',
-  'base',
-  'br',
-  'col',
-  'command',
-  'embed',
-  'hr',
-  'img',
-  'input',
-  'keygen',
-  'link',
-  'meta',
-  'param',
-  'source',
-  'track',
-  'wbr',
-]);
 
 module.exports = class ParseResult {
   constructor(template) {
@@ -299,291 +280,24 @@ module.exports = class ParseResult {
     }
   }
 
-  print(ast = this._originalAst) {
-    if (!ast) {
+  print(_ast = this._originalAst) {
+    if (!_ast) {
       return '';
     }
 
-    // TODO: this isn't quite right, it forces the whole subtree
-    // to be reprinted which isn't correct
-    if (this.nodeInfo.has(ast)) {
-      return this._printKnownNode(ast);
-    } else {
-      return this._printNewNode(ast);
-    }
-  }
-
-  /*
-    TODO: this is _nearly_ copied from @glimmer/syntax directly (with some small changes)
-
-    We should tweak the printer in @glimmer/syntax to allow a custom print function to be used instead of directly
-    recursing. This would allow us to use our own custom "reprint" code but still do the "right thing" for new nodes.
-  */
-  _printNewNode(ast) {
-    if (!ast) {
-      return '';
-    }
-
-    const parseResult = this;
-
-    function buildEach(asts) {
-      return asts.map(node => parseResult.print(node));
-    }
-
-    function pathParams(ast) {
-      let path;
-
-      switch (ast.type) {
-        case 'MustacheStatement':
-        case 'SubExpression':
-        case 'ElementModifierStatement':
-        case 'BlockStatement':
-          path = parseResult.print(ast.path);
-          break;
-        case 'PartialStatement':
-          path = parseResult.print(ast.name);
-          break;
-        default:
-          throw new Error('unreachable');
-      }
-
-      return compactJoin([path, buildEach(ast.params).join(' '), parseResult.print(ast.hash)], ' ');
-    }
-
-    function blockParams(block) {
-      const params = block.program.blockParams;
-      if (params.length) {
-        return ` as |${params.join(' ')}|`;
-      }
-
-      return null;
-    }
-
-    function openBlock(block) {
-      return compactJoin([
-        '{{',
-        block.openStrip.open ? '~' : null,
-        '#',
-        pathParams(block),
-        blockParams(block),
-        block.openStrip.close ? '~' : null,
-        '}}',
-      ]);
-    }
-
-    function closeBlock(block) {
-      return compactJoin([
-        '{{',
-        block.closeStrip.open ? '~' : null,
-        '/',
-        parseResult.print(block.path),
-        block.closeStrip.close ? '~' : null,
-        '}}',
-      ]);
-    }
-
-    const output = [];
-
-    switch (ast.type) {
-      case 'Program':
-      case 'Block':
-      case 'Template':
-        {
-          const chainBlock = ast.chained && ast.body[0];
-          if (chainBlock) {
-            chainBlock.chained = true;
-          }
-          const body = buildEach(ast.body).join('');
-          output.push(body);
-        }
-        break;
-      case 'ElementNode':
-        output.push('<', ast.tag);
-        if (ast.attributes.length) {
-          output.push(' ', buildEach(ast.attributes).join(' '));
-        }
-        if (ast.modifiers.length) {
-          output.push(' ', buildEach(ast.modifiers).join(' '));
-        }
-        if (ast.comments.length) {
-          output.push(' ', buildEach(ast.comments).join(' '));
-        }
-
-        if (ast.blockParams.length) {
-          output.push(' ', 'as', ' ', `|${ast.blockParams.join(' ')}|`);
-        }
-
-        if (voidElements.has(ast.tag)) {
-          if (ast.selfClosing) {
-            output.push(' /');
-          }
-
-          output.push('>');
-        } else if (ast.selfClosing) {
-          output.push(' />');
-        } else {
-          output.push('>');
-          output.push.apply(output, buildEach(ast.children));
-          output.push('</', ast.tag, '>');
-        }
-        break;
-      case 'AttrNode':
-        if (ast.value.type === 'TextNode') {
-          if (ast.value.chars !== '') {
-            output.push(ast.name, '=');
-            output.push('"', ast.value.chars, '"');
-          } else {
-            output.push(ast.name);
-          }
-        } else {
-          output.push(ast.name, '=');
-          // ast.value is mustache or concat
-          output.push(parseResult.print(ast.value));
-        }
-        break;
-      case 'ConcatStatement':
-        output.push('"');
-        ast.parts.forEach(node => {
-          if (node.type === 'TextNode') {
-            output.push(node.chars);
-          } else {
-            output.push(parseResult.print(node));
-          }
-        });
-        output.push('"');
-        break;
-      case 'TextNode':
-        output.push(ast.chars);
-        break;
-      case 'MustacheStatement':
-        {
-          output.push(
-            compactJoin([
-              ast.escaped ? '{{' : '{{{',
-              ast.strip.open ? '~' : null,
-              pathParams(ast),
-              ast.strip.close ? '~' : null,
-              ast.escaped ? '}}' : '}}}',
-            ])
-          );
-        }
-        break;
-      case 'MustacheCommentStatement':
-        {
-          output.push(compactJoin(['{{!--', ast.value, '--}}']));
-        }
-        break;
-      case 'ElementModifierStatement':
-        {
-          output.push(compactJoin(['{{', pathParams(ast), '}}']));
-        }
-        break;
-      case 'PathExpression':
-        output.push(ast.original);
-        break;
-      case 'SubExpression':
-        {
-          output.push('(', pathParams(ast), ')');
-        }
-        break;
-      case 'BooleanLiteral':
-        output.push(ast.value ? 'true' : 'false');
-        break;
-      case 'BlockStatement':
-        {
-          const lines = [];
-
-          if (ast.chained) {
-            lines.push(
-              compactJoin([
-                '{{',
-                ast.inverseStrip.open ? '~' : null,
-                'else ',
-                pathParams(ast),
-                ast.inverseStrip.close ? '~' : null,
-                '}}',
-              ])
-            );
-          } else {
-            lines.push(openBlock(ast));
-          }
-
-          lines.push(parseResult.print(ast.program));
-
-          if (ast.inverse) {
-            if (!ast.inverse.chained) {
-              lines.push(
-                compactJoin([
-                  '{{',
-                  ast.inverseStrip.open ? '~' : null,
-                  'else',
-                  ast.inverseStrip.close ? '~' : null,
-                  '}}',
-                ])
-              );
-            }
-            lines.push(parseResult.print(ast.inverse));
-          }
-
-          if (!ast.chained) {
-            lines.push(closeBlock(ast));
-          }
-
-          output.push(lines.join(''));
-        }
-        break;
-      case 'PartialStatement':
-        {
-          output.push(compactJoin(['{{>', pathParams(ast), '}}']));
-        }
-        break;
-      case 'CommentStatement':
-        {
-          output.push(compactJoin(['<!--', ast.value, '-->']));
-        }
-        break;
-      case 'StringLiteral':
-        {
-          output.push(`"${ast.value}"`);
-        }
-        break;
-      case 'NumberLiteral':
-        {
-          output.push(String(ast.value));
-        }
-        break;
-      case 'UndefinedLiteral':
-        {
-          output.push('undefined');
-        }
-        break;
-      case 'NullLiteral':
-        {
-          output.push('null');
-        }
-        break;
-      case 'Hash':
-        {
-          output.push(
-            ast.pairs
-              .map(pair => {
-                return parseResult.print(pair);
-              })
-              .join(' ')
-          );
-        }
-        break;
-      case 'HashPair':
-        {
-          output.push(`${ast.key}=${parseResult.print(ast.value)}`);
-        }
-        break;
-    }
-    return output.join('');
-  }
-
-  _printKnownNode(_ast) {
     let nodeInfo = this.nodeInfo.get(_ast);
+
+    if (nodeInfo === undefined) {
+      return _print(_ast, {
+        entityEncoding: 'raw',
+
+        override: ast => {
+          if (this.nodeInfo.has(ast)) {
+            return this.print(ast);
+          }
+        },
+      });
+    }
 
     // this ensures that we are operating on the actual node and not a
     // proxy (we can get Proxies here when transforms splice body/children)

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,25 +114,25 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@glimmer/interfaces@^0.41.3":
-  version "0.41.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.41.3.tgz#33cc6e0e1d7c2696ad59c1b68d723e9c1ea944ec"
-  integrity sha512-EgJYw+2YyMztC2O2yuhRfb2SlAxXGBx6ug4b6qnjLrpypsKFZEE17/2gDi+f8lPFQct96uQW8ja4w9RQI85vMw==
+"@glimmer/interfaces@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.41.4.tgz#3f3e26abea8a4e1463130e9a75e94372781d154b"
+  integrity sha512-MzXwMyod3MlwSZezHSaVBsCEIW/giYYfTDYARR46QnYsaFVatMVbydjsI7jkAuBCbnLCyNOIc1TrYIj71i/rpg==
 
-"@glimmer/syntax@^0.41.3":
-  version "0.41.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.41.3.tgz#f8feab2a6f24c922a8950992ca56bb9980d2b571"
-  integrity sha512-sHNqAGNMX4vs7gqRCye3F2COxu5sZKB/45Uclyn58GMVkIcRXYGyggKxMEH+m5fOvoAjhQPawjRBnsi/ccfR1A==
+"@glimmer/syntax@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.41.4.tgz#9c0c763aab44069c828ce782947c84d31ff75879"
+  integrity sha512-NLPNirZDbNmpZ8T/ccle22zt2rhUq5il7ST6IJk62T58QZeJsdr3m3RS4kaGSBsQhXoKELrgX048yYEX5sC+fw==
   dependencies:
-    "@glimmer/interfaces" "^0.41.3"
-    "@glimmer/util" "^0.41.3"
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
     handlebars "^4.0.13"
     simple-html-tokenizer "^0.5.7"
 
-"@glimmer/util@^0.41.3":
-  version "0.41.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.41.3.tgz#52e34c0c4dc0fdf56f8e4bda3f119269067b0887"
-  integrity sha512-CdrBBJVfQNhy6YX7itj65lI4q29SW5BGaPFR9WgOMd5snFQ4CbSymdFAdiV8QNRBs2Ax27FKrC3ciGZ9qtZ6Ew==
+"@glimmer/util@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.41.4.tgz#508fd82ca40305416e130f0da7b537295ded7989"
+  integrity sha512-DwS94K+M0vtG+cymxH0rslJr09qpdjyOLdCjmpKcG/nNiZQfMA1ybAaFEmwk9UaVlUG9STENFeQwyrLevJB+7g==
 
 "@iarna/toml@2.2.3":
   version "2.2.3"


### PR DESCRIPTION
* Update `@glimmer/syntax` to 0.41.4
* Use the changes added in https://github.com/glimmerjs/glimmer-vm/pull/957 to allow removing the duplication added in #74.