### PR TITLE
Ensure proxy mapping is maintained during set/delete.

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -75,6 +75,10 @@ module.exports = class ParseResult {
       },
 
       set: (target, property, value) => {
+        if (propertyProxyMap.has(property)) {
+          propertyProxyMap.set(property, value);
+        }
+
         Reflect.set(target, property, value);
 
         if (hasLocInfo) {
@@ -87,6 +91,10 @@ module.exports = class ParseResult {
       },
 
       deleteProperty: (target, property) => {
+        if (propertyProxyMap.has(property)) {
+          propertyProxyMap.delete(property);
+        }
+
         let result = Reflect.deleteProperty(target, property);
 
         if (hasLocInfo) {
@@ -105,6 +113,7 @@ module.exports = class ParseResult {
 
     for (let key in node) {
       let value = node[key];
+
       if (typeof value === 'object' && value !== null) {
         let propertyProxy = this.wrapNode({ node, key }, value);
 

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -328,6 +328,29 @@ QUnit.module('ember-template-recast', function() {
 
       assert.equal(print(ast), '<Foo>some text</Foo>');
     });
+
+    QUnit.test('moving a child to another ElementNode', function(assert) {
+      let template = stripIndent`
+        <Foo>{{
+          special-formatting-here
+        }}</Foo>
+      `;
+
+      let ast = parse(template);
+      let child = ast.body[0].children.pop();
+      ast.body.unshift(builders.text('\n'));
+      ast.body.unshift(child);
+
+      assert.equal(
+        print(ast),
+        stripIndent`
+          {{
+            special-formatting-here
+          }}
+          <Foo></Foo>
+        `
+      );
+    });
   });
 
   QUnit.module('MustacheStatement', function() {
@@ -992,7 +1015,7 @@ QUnit.module('ember-template-recast', function() {
     });
   });
 
-  QUnit.todo('can remove during traversal by returning `null`', function(assert) {
+  QUnit.test('can remove during traversal by returning `null`', function(assert) {
     let template = stripIndent`
     <p>here is some multiline string</p>
     {{ other-stuff }}


### PR DESCRIPTION
Previously, when a mutation of an existing property occurred the proxy system that we had in place would never reflect those changes externally. This meant that some operations (initially identified as array operations) would be lost when moving existing properties unchanged.

This ensures that the underlying proxy / property detection system will reflect the changes that are made when accessing the properties subsequently.

Fixes #77