### PR TITLE
Ensure updating a void element does not print a closing tag.

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -7,6 +7,25 @@ const trailingWhitespace = /(\s+)$/;
 const attrNodeParts = /(^[^=]+)(\s+)?(=)?(\s+)?(\S+)?/;
 const hashPairParts = /(^[^=]+)(\s+)?=(\s+)?(\S+)/;
 
+const voidTagNames = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'command',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'keygen',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
 module.exports = class ParseResult {
   constructor(template) {
     let ast = preprocess(template, {
@@ -427,11 +446,16 @@ module.exports = class ParseResult {
               })
             : '';
 
-          let closeSource = selfClosing ? '' : `</${original.tag}>`;
+          let closeSource = selfClosing
+            ? ''
+            : voidTagNames.has(original.tag)
+            ? ''
+            : `</${original.tag}>`;
 
           if (dirtyFields.has('tag')) {
             openSource = `<${ast.tag}`;
-            closeSource = selfClosing ? '' : `</${ast.tag}>`;
+
+            closeSource = selfClosing ? '' : voidTagNames.has(ast.tag) ? '' : `</${ast.tag}>`;
 
             dirtyFields.delete('tag');
           }

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -4,6 +4,44 @@ const { stripIndent } = require('common-tags');
 
 QUnit.module('ember-template-recast', function() {
   QUnit.module('ElementNode', function() {
+    QUnit.test('creating void element', function(assert) {
+      let template = ``;
+
+      let ast = parse(template);
+      ast.body.push(builders.element('img'));
+
+      assert.equal(print(ast), `<img>`);
+    });
+
+    QUnit.test('updating attributes on a non-self-closing void element', function(assert) {
+      let template = `<img src="{{something}}">`;
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value.parts[0].path = builders.path('this.something');
+
+      assert.equal(print(ast), `<img src="{{this.something}}">`);
+    });
+
+    QUnit.test('changing an element to a void element does not print closing tag', function(
+      assert
+    ) {
+      let template = `<div data-foo="{{something}}"></div>`;
+
+      let ast = parse(template);
+      ast.body[0].tag = 'img';
+
+      assert.equal(print(ast), `<img data-foo="{{something}}">`);
+    });
+
+    QUnit.test('updating attributes on a self-closing void element', function(assert) {
+      let template = `<img src="{{something}}" />`;
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value.parts[0].path = builders.path('this.something');
+
+      assert.equal(print(ast), `<img src="{{this.something}}" />`);
+    });
+
     QUnit.test('rename element tagname', function(assert) {
       let template = stripIndent`
       <div data-foo='single quoted'>


### PR DESCRIPTION
Fix https://github.com/ember-codemods/ember-no-implicit-this-codemod/issues/13