### PR TITLE
Fix mutating an element attribute with an initial valueless attribute.

### DIFF
--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -149,6 +149,37 @@ QUnit.module('ember-template-recast', function() {
       );
     });
 
+    QUnit.test('modifying attribute after valueless attribute', function(assert) {
+      let template = '<Foo data-foo data-derp={{hmmm}} />';
+
+      let ast = parse(template);
+      ast.body[0].attributes[1].value.path = builders.path('this.hmmm');
+
+      assert.equal(print(ast), '<Foo data-foo data-derp={{this.hmmm}} />');
+    });
+
+    QUnit.test('modifying attribute after valueless attribute with special whitespace', function(
+      assert
+    ) {
+      let template = stripIndent`
+        <Foo
+          data-foo
+          data-derp={{hmmm}}
+        />`;
+
+      let ast = parse(template);
+      ast.body[0].attributes[1].value.path = builders.path('this.hmmm');
+
+      assert.equal(
+        print(ast),
+        stripIndent`
+          <Foo
+            data-foo
+            data-derp={{this.hmmm}}
+          />`
+      );
+    });
+
     QUnit.test('adding attribute after valueless attribute', function(assert) {
       let template = '<Foo data-foo />';
 


### PR DESCRIPTION
Due to glimmerjs/glimmer-vm#953 checking the spacing between an initial attribute and a subsequent attribute will not work properly when the initial attribute is "value less".

This fixes the prior issue by ensuring that we fix the AST **before** we save off any original source information.

Fixes https://github.com/ember-codemods/ember-no-implicit-this-codemod/issues/15
Fixes https://github.com/ember-template-lint/ember-template-recast/issues/83