### PR TITLE
Simple attribute indentation fails with codemod mock

### DIFF
--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -523,8 +523,8 @@ QUnit.module('"real life" smoke tests', function() {
         code,
         stripIndent`
         <FooBar 
-          @goes=here
-          @and=here
+          @goes={{here}}
+          @and={{here}}
         }} />
       `
       );

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -508,5 +508,26 @@ QUnit.module('"real life" smoke tests', function() {
       `
       );
     });
+
+    QUnit.test('preserves simple attribute indentation', function(assert) {
+      let template = stripIndent`
+        {{foo-bar 
+          goes=here
+          and=here
+        }}
+      `;
+
+      let { code } = transform(template, codemod);
+
+      assert.equal(
+        code,
+        stripIndent`
+        <FooBar 
+          @goes=here
+          @and=here
+        }} />
+      `
+      );
+    });
   });
 });


### PR DESCRIPTION
Small example of #84 using existing test.