### PR TITLE
Reexport `builders` from `@glimmer/syntax`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ function transform(template, plugin) {
 }
 
 module.exports = {
+  builders,
   parse,
   print,
   transform,


### PR DESCRIPTION
We already have `builders` as part of our public API because we pass it to the plugin in the `transform()` function. Only having access to the builders within that plugin makes the implementation a bit cumbersome though. I don't see a reason why we shouldn't just reexport it directly too, so that implementing helper functions becomes easier.