### PR TITLE
Ensure chained inverses are properly printed.

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -725,8 +725,8 @@ module.exports = class ParseResult {
 
           let inverseSource = hadInverse ? this.sourceForLoc(original.inverse.loc) : '';
 
-          let endSource;
-          {
+          let endSource = '';
+          if (!ast.wasChained) {
             let firstOpenCurlyFromEndIndex = nodeInfo.source.lastIndexOf('{');
             let secondOpenCurlyFromEndIndex = nodeInfo.source.lastIndexOf(
               '{',
@@ -789,9 +789,10 @@ module.exports = class ParseResult {
               inversePreamble = '';
             } else {
               if (ast.inverse.chained) {
-                inverseSource = ast.inverse.body[0].program.body
-                  .map(child => this.print(child))
-                  .join('');
+                inversePreamble = '';
+                let inverseBody = ast.inverse.body[0];
+                inverseBody.wasChained = true;
+                inverseSource = this.print(inverseBody);
               } else {
                 inverseSource = ast.inverse.body.map(child => this.print(child)).join('');
               }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -211,5 +211,44 @@ QUnit.module('ember-template-recast', function() {
 
       assert.equal(code, '{{foo-bar hello="world"}}{{#baz}}Hello!{{/baz}}');
     });
+
+    QUnit.test('nested else-if', function(assert) {
+      let template = `
+        {{#if a}}
+          {{foo}}
+        {{else if b}}
+          {{bar}}
+        {{else if c}}
+          {{baz}}
+        {{else}}
+          {{qux}}
+        {{/if}}
+      `;
+
+      let expected = `
+        {{#if a}}
+          {{oof}}
+        {{else if b}}
+          {{rab}}
+        {{else if c}}
+          {{zab}}
+        {{else}}
+          {{xuq}}
+        {{/if}}
+      `;
+
+      let { code } = transform(template, () => {
+        return {
+          MustacheStatement(node) {
+            node.path.original = node.path.original
+              .split('')
+              .reverse()
+              .join('');
+          },
+        };
+      });
+
+      assert.equal(code, expected);
+    });
   });
 });

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -211,44 +211,5 @@ QUnit.module('ember-template-recast', function() {
 
       assert.equal(code, '{{foo-bar hello="world"}}{{#baz}}Hello!{{/baz}}');
     });
-
-    QUnit.test('nested else-if', function(assert) {
-      let template = `
-        {{#if a}}
-          {{foo}}
-        {{else if b}}
-          {{bar}}
-        {{else if c}}
-          {{baz}}
-        {{else}}
-          {{qux}}
-        {{/if}}
-      `;
-
-      let expected = `
-        {{#if a}}
-          {{oof}}
-        {{else if b}}
-          {{rab}}
-        {{else if c}}
-          {{zab}}
-        {{else}}
-          {{xuq}}
-        {{/if}}
-      `;
-
-      let { code } = transform(template, () => {
-        return {
-          MustacheStatement(node) {
-            node.path.original = node.path.original
-              .split('')
-              .reverse()
-              .join('');
-          },
-        };
-      });
-
-      assert.equal(code, expected);
-    });
   });
 });


### PR DESCRIPTION
Previously, when a chained inverse was updated we would only reprint the inverse's `program` node. This meant that if you used a chained inverse **and** a terminal inverse that reprinting the entire statement would loose parts of the original template.

The reason we previously only printed the inverse's `program` was because in the case where the inverse itself is chained, there is actually no valid "end source" for that nested `BlockStatement` (😩).

The fix here is to "mark" the `BlockStatement` that is part of a chained inverse _before_ attempting to print it, and when printing chained inverse `BlockStatement`'s recursively avoid attempting to emit an `endSource` (because there is none).

Closes #125 
Fixes #126 