### PR TITLE
Ensure `TextNode`s are quoted in `AttrNode.value`

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -857,6 +857,10 @@ module.exports = class ParseResult {
             valueSource,
           ] = source.match(attrNodeParts);
 
+          // does not include ConcatStatement because `_print` automatically
+          // adds a `"` around them, meaning we do not need to add our own quotes
+          let wasQuotableValue = original.value.type === 'TextNode';
+
           let openQuote = '';
           let closeQuote = '';
 
@@ -878,6 +882,13 @@ module.exports = class ParseResult {
           }
 
           if (dirtyFields.has('value')) {
+            let newValueNeedsQuotes = ast.value.type === 'TextNode';
+
+            if (!wasQuotableValue && newValueNeedsQuotes) {
+              openQuote = '"';
+              closeQuote = '"';
+            }
+
             valueSource = this.print(ast.value);
 
             dirtyFields.delete('value');

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -42,6 +42,16 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), `<img src="{{this.something}}" />`);
     });
 
+    QUnit.test('changing an attribute value from mustache to text node (GH#111)', function(assert) {
+      let template = `<FooBar @thing={{1234}} @baz={{derp}} />`;
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value = builders.text('static thing 1');
+      ast.body[0].attributes[1].value = builders.text('static thing 2');
+
+      assert.equal(print(ast), `<FooBar @thing="static thing 1" @baz="static thing 2" />`);
+    });
+
     QUnit.test('rename element tagname', function(assert) {
       let template = stripIndent`
       <div data-foo='single quoted'>
@@ -1013,6 +1023,28 @@ QUnit.module('ember-template-recast', function() {
       ast.body[0].attributes[0].value.path.original = 'bar';
 
       assert.equal(print(ast), '<Foo bar={{bar}} />');
+    });
+
+    QUnit.test('updating value from non-quotable to TextNode (GH#111)', function(assert) {
+      let template = '<Foo bar={{foo}} />';
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value = builders.text('hello!');
+
+      assert.equal(print(ast), '<Foo bar="hello!" />');
+    });
+
+    QUnit.test('updating value from non-quotable to ConcatStatement (GH#111)', function(assert) {
+      let template = '<Foo bar={{foo}} />';
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value = builders.concat([
+        builders.mustache('foo'),
+        builders.text(' static '),
+        builders.mustache('bar'),
+      ]);
+
+      assert.equal(print(ast), '<Foo bar="{{foo}} static {{bar}}" />');
     });
 
     QUnit.test('renaming valueless attribute', function(assert) {


### PR DESCRIPTION
Previously, when converting an `AttrNode` from `data-foo={{anything}}` to `data-foo="some text"` we would not emit quotes surrounding the new `AttrNode` value, and therefore would emit invalid HTML/HBS output.

This problem was restricted to scenarios where the _original_ `AttrNode`'s value was unquoted (e.g. it was a mustache value).

Fixes #111