### PR TITLE
Fix issues with adding to a `ConcatStatement`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "qunit tests/**/*-test.js"
   },
   "dependencies": {
-    "@glimmer/syntax": "^0.42.0",
+    "@glimmer/syntax": "^0.42.2",
     "async-promise-queue": "^1.0.5",
     "colors": "^1.3.3",
     "commander": "^3.0.0",

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -1025,6 +1025,15 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), '<Foo bar={{bar}} />');
     });
 
+    QUnit.test('updating concat statement value', function(assert) {
+      let template = '<Foo class="{{foo}} static {{bar}}" />';
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value.parts.push(builders.text(' other-static'));
+
+      assert.equal(print(ast), '<Foo class="{{foo}} static {{bar}} other-static" />');
+    });
+
     QUnit.test('updating value from non-quotable to TextNode (GH#111)', function(assert) {
       let template = '<Foo bar={{foo}} />';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,25 +26,25 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@glimmer/interfaces@^0.42.1":
-  version "0.42.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.42.1.tgz#dff06df250165bdaf00221df2080f4e69fc4d117"
-  integrity sha512-n1bO77b51OKXXnB3WYglbdh51YlrJZQjNm3eH+fKzuca+Mmc2YZsJmlSLGa9FyQNmRE7mkvSuTuWuvARMdXo7g==
+"@glimmer/interfaces@^0.42.2":
+  version "0.42.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.42.2.tgz#9cf8d6f8f5eee6bfcfa36919ca68ae716e1f78db"
+  integrity sha512-7LOuQd02cxxNNHChzdHMAU8/qOeQvTro141CU5tXITP7z6aOv2D2gkFdau97lLQiVxezGrh8J7h8GCuF7TEqtg==
 
-"@glimmer/syntax@^0.42.0":
-  version "0.42.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.42.1.tgz#b1cd2afebbec2aec988cd12fe2f496710e3f55eb"
-  integrity sha512-9tQTqrXDZeD4YbaWI4mABVxDsORyYCfmfZu9fQWTwHAIr4fubrOBEk1wvkPTvxwJmDe4dBzQAYNOmLPC3XkA6Q==
+"@glimmer/syntax@^0.42.2":
+  version "0.42.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.42.2.tgz#89bb3cb787285b84665dc0d8907d94b008e5be9a"
+  integrity sha512-SR26SmF/Mb5o2cc4eLHpOyoX5kwwXP4KRhq4fbWfrvan74xVWA38PLspPCzwGhyVH/JsE7tUEPMjSo2DcJge/Q==
   dependencies:
-    "@glimmer/interfaces" "^0.42.1"
-    "@glimmer/util" "^0.42.1"
+    "@glimmer/interfaces" "^0.42.2"
+    "@glimmer/util" "^0.42.2"
     handlebars "^4.0.13"
     simple-html-tokenizer "^0.5.8"
 
-"@glimmer/util@^0.42.1":
-  version "0.42.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.1.tgz#8c768c8971d8897a0c63411a09a20ea825b5efb9"
-  integrity sha512-jS8bskv1wee9d0YkGpX/Xh58dHiH8nrhMZ9k7W9l06Ey9QgucqGdmJirdh/aS8yffb4fqloLjhPMef6C2DnHsQ==
+"@glimmer/util@^0.42.2":
+  version "0.42.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.2.tgz#9ca1631e42766ea6059f4b49d0bdfb6095aad2c4"
+  integrity sha512-Heck0baFSaWDanCYtmOcLeaz7v+rSqI8ovS7twrp2/FWEteb3Ze5sWQ2BEuSAG23L/k/lzVwYM/MY7ZugxBpaA==
 
 "@iarna/toml@2.2.3":
   version "2.2.3"


### PR DESCRIPTION
Prior to `@glimmer/syntax@0.42.2` this test would have emitted:

```hbs
<Foo class="{{foo}}static {{bar}} other-static" />
```

The actual fix is upstream in https://github.com/glimmerjs/glimmer-vm/pull/979.