### PR TITLE
Ensure AttrNode and HashPair values are preserved if changing name/key.

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -826,9 +826,8 @@ module.exports = class ParseResult {
       case 'HashPair':
         {
           let { source } = nodeInfo;
-          let [, keySource, postKeyWhitespace, postEqualsWhitespace, valueSource] = source.match(
-            hashPairParts
-          );
+          let [, keySource, postKeyWhitespace, postEqualsWhitespace] = source.match(hashPairParts);
+          let valueSource = this.sourceForLoc(original.value.loc);
 
           if (dirtyFields.has('key')) {
             keySource = ast.key;
@@ -848,14 +847,10 @@ module.exports = class ParseResult {
       case 'AttrNode':
         {
           let { source } = nodeInfo;
-          let [
-            ,
-            nameSource,
-            postNameWhitespace,
-            equals,
-            postEqualsWhitespace,
-            valueSource,
-          ] = source.match(attrNodeParts);
+          let [, nameSource, postNameWhitespace, equals, postEqualsWhitespace] = source.match(
+            attrNodeParts
+          );
+          let valueSource = this.sourceForLoc(original.value.loc);
 
           // does not include ConcatStatement because `_print` automatically
           // adds a `"` around them, meaning we do not need to add our own quotes

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -159,6 +159,26 @@ QUnit.module('ember-template-recast', function() {
       );
     });
 
+    QUnit.test('modifying an attribute name (GH#112)', function(assert) {
+      let template = stripIndent`
+        <div
+          data-foo='some thing here'
+          data-bar=hahaha
+        ></div>`;
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].name = 'data-test';
+
+      assert.equal(
+        print(ast),
+        stripIndent`
+          <div
+            data-test='some thing here'
+            data-bar=hahaha
+          ></div>`
+      );
+    });
+
     QUnit.test('modifying attribute after valueless attribute', function(assert) {
       let template = '<Foo data-foo data-derp={{hmmm}} />';
 
@@ -811,6 +831,27 @@ QUnit.module('ember-template-recast', function() {
       ast.body[0].hash.pairs.push(builders.pair('hello', builders.string('world')));
 
       assert.equal(print(ast), '{{#foo-bar hello="world" as |a b c|}}Hi there!{{/foo-bar}}');
+    });
+
+    QUnit.test('changing a HashPair key with a StringLiteral value (GH#112)', function(assert) {
+      let template = `{{#foo-bar foo="some thing with a space"}}Hi there!{{/foo-bar}}`;
+
+      let ast = parse(template);
+      ast.body[0].hash.pairs[0].key = 'bar';
+
+      assert.equal(print(ast), '{{#foo-bar bar="some thing with a space"}}Hi there!{{/foo-bar}}');
+    });
+
+    QUnit.test('changing a HashPair key with a SubExpression value (GH#112)', function(assert) {
+      let template = `{{#foo-bar foo=(helper-here this.arg1 this.arg2)}}Hi there!{{/foo-bar}}`;
+
+      let ast = parse(template);
+      ast.body[0].hash.pairs[0].key = 'bar';
+
+      assert.equal(
+        print(ast),
+        '{{#foo-bar bar=(helper-here this.arg1 this.arg2)}}Hi there!{{/foo-bar}}'
+      );
     });
 
     QUnit.test('adding param with no params or hash', function(assert) {


### PR DESCRIPTION
Prior to this change, we retrieved the original source for a `HashPair`/`AttrNode` value via a regular expression. The regexp is needed in order to capture the actual source of the `key` / `name` because there is no location information in the AST, however using a regexp for matching the value was causing needless issues. The `AttrNode`/`HashPair` `.value` will _always_ have its own location information, and we should use that instead of a regexp to build up the original source of the value.

Fixes #112