### PR TITLE
Handle attr change from text node to mustache

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -882,6 +882,9 @@ module.exports = class ParseResult {
             if (!wasQuotableValue && newValueNeedsQuotes) {
               openQuote = '"';
               closeQuote = '"';
+            } else if (wasQuotableValue && !newValueNeedsQuotes) {
+              openQuote = '';
+              closeQuote = '';
             }
 
             valueSource = this.print(ast.value);

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -52,32 +52,39 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), `<FooBar @thing="static thing 1" @baz="static thing 2" />`);
     });
 
-    QUnit.test('changing an attribute value from text node to mustache (GH #139)', function(assert) {
+    QUnit.test('changing an attribute value from text node to mustache (GH #139)', function(
+      assert
+    ) {
       let template = `<FooBar @foo="Hi, I'm a string!" />`;
 
       let ast = parse(template);
       ast.body[0].attributes[0].value = builders.mustache('my-awesome-helper', [
-        builders.string("hello"),
-        builders.string("world")
+        builders.string('hello'),
+        builders.string('world'),
       ]);
 
       assert.equal(print(ast), `<FooBar @foo={{my-awesome-helper "hello" "world"}} />`);
     });
 
-    QUnit.test('changing an attribute value from text node to concat statement (GH #139)', function(assert) {
+    QUnit.test('changing an attribute value from text node to concat statement (GH #139)', function(
+      assert
+    ) {
       let template = `<FooBar @foo="Hi, I'm a string!" />`;
 
       let ast = parse(template);
       ast.body[0].attributes[0].value = builders.concat([
-        builders.text("Hello "),
+        builders.text('Hello '),
         builders.mustache('my-awesome-helper', [
-          builders.string("hello"),
-          builders.string("world")
+          builders.string('hello'),
+          builders.string('world'),
         ]),
-        builders.text(" world")
+        builders.text(' world'),
       ]);
 
-      assert.equal(print(ast), `<FooBar @foo="Hello {{my-awesome-helper "hello" "world"}} world" />`);
+      assert.equal(
+        print(ast),
+        `<FooBar @foo="Hello {{my-awesome-helper "hello" "world"}} world" />`
+      );
     });
 
     QUnit.test('changing an attribute value from mustache to mustache', function(assert) {
@@ -85,8 +92,8 @@ QUnit.module('ember-template-recast', function() {
 
       let ast = parse(template);
       ast.body[0].attributes[0].value = builders.mustache('my-awesome-helper', [
-        builders.string("hello"),
-        builders.string("world")
+        builders.string('hello'),
+        builders.string('world'),
       ]);
 
       assert.equal(print(ast), `<FooBar @foo={{my-awesome-helper "hello" "world"}} />`);

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -52,6 +52,46 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), `<FooBar @thing="static thing 1" @baz="static thing 2" />`);
     });
 
+    QUnit.test('changing an attribute value from text node to mustache (GH #139)', function(assert) {
+      let template = `<FooBar @foo="Hi, I'm a string!" />`;
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value = builders.mustache('my-awesome-helper', [
+        builders.string("hello"),
+        builders.string("world")
+      ]);
+
+      assert.equal(print(ast), `<FooBar @foo={{my-awesome-helper "hello" "world"}} />`);
+    });
+
+    QUnit.test('changing an attribute value from text node to concat statement (GH #139)', function(assert) {
+      let template = `<FooBar @foo="Hi, I'm a string!" />`;
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value = builders.concat([
+        builders.text("Hello "),
+        builders.mustache('my-awesome-helper', [
+          builders.string("hello"),
+          builders.string("world")
+        ]),
+        builders.text(" world")
+      ]);
+
+      assert.equal(print(ast), `<FooBar @foo="Hello {{my-awesome-helper "hello" "world"}} world" />`);
+    });
+
+    QUnit.test('changing an attribute value from mustache to mustache', function(assert) {
+      let template = `<FooBar @foo={{12345}} />`;
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value = builders.mustache('my-awesome-helper', [
+        builders.string("hello"),
+        builders.string("world")
+      ]);
+
+      assert.equal(print(ast), `<FooBar @foo={{my-awesome-helper "hello" "world"}} />`);
+    });
+
     QUnit.test('rename element tagname', function(assert) {
       let template = stripIndent`
       <div data-foo='single quoted'>

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -901,6 +901,27 @@ QUnit.module('ember-template-recast', function() {
       );
     });
 
+    QUnit.test('changing a HashPair value from StringLiteral to SubExpression', function(assert) {
+      let template = `{{#foo-bar foo="bar!"}}Hi there!{{/foo-bar}}`;
+
+      let ast = parse(template);
+      ast.body[0].hash.pairs[0].value = builders.sexpr('concat', [
+        builders.string('hello'),
+        builders.string('world'),
+      ]);
+
+      assert.equal(print(ast), '{{#foo-bar foo=(concat "hello" "world")}}Hi there!{{/foo-bar}}');
+    });
+
+    QUnit.test('changing a HashPair value from SubExpression to StringLiteral', function(assert) {
+      let template = `{{#foo-bar foo=(concat "hello" "world")}}Hi there!{{/foo-bar}}`;
+
+      let ast = parse(template);
+      ast.body[0].hash.pairs[0].value = builders.string('hello world!');
+
+      assert.equal(print(ast), '{{#foo-bar foo="hello world!"}}Hi there!{{/foo-bar}}');
+    });
+
     QUnit.test('adding param with no params or hash', function(assert) {
       let template = `{{#foo-bar}}Hi there!{{/foo-bar}}`;
 


### PR DESCRIPTION
Fixes GH #139.

Handles the opposite of #111: if the old value was a quotable value and the new one isn't, remove the quotes.