### PR TITLE
Add Windows and macOS CI testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,12 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         node: ['^8.12', '10', '12']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/tests/ember-template-recast-test.js
+++ b/tests/ember-template-recast-test.js
@@ -2,6 +2,7 @@ const execa = require('execa');
 const { readFileSync } = require('fs');
 const { join } = require('path');
 const { createTempDir } = require('broccoli-test-helper');
+const slash = require('slash');
 
 function run(args, cwd) {
   return execa(require.resolve('../bin/ember-template-recast'), args, { cwd });
@@ -104,10 +105,13 @@ Errored:   1`
         'Status message includes error count'
       );
 
-      assert.ok(
-        stdout.includes(join(this.fixture.path(), 'files/bad-template.hbs')),
-        'Output includes full path to bad template'
-      );
+      let badFilePath = slash(join(this.fixture.path(), 'files/bad-template.hbs'));
+
+      assert.pushResult({
+        result: stdout.includes(badFilePath),
+        message: `Expected output to include full path to the invalid template (${badFilePath}): \n\n${stdout}`,
+      });
+
       assert.ok(
         stdout.includes('Error: Parse error on line 1:'),
         'Output includes error stacktrace'


### PR DESCRIPTION
Fixes needed to move forward:

- [x] Avoid using `child_process.spawn` in tests https://github.com/ember-template-lint/ember-template-recast/pull/145
- [x] Always use posix paths when globbing https://github.com/ember-template-lint/ember-template-recast/pull/147
- [x] Work around issues in sindresorhus/globby#133 (pending a fix for Windows specific issue in sindresorhus/globby#137)
- [x] Fix test assertions relying on platform specific path formatting