### PR TITLE
Fix looping logic in markAsDirty()

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -205,9 +205,8 @@ module.exports = class ParseResult {
     dirtyFields.add(property);
 
     let ancestor = this.ancestor.get(node);
-    while (ancestor !== null) {
+    if (ancestor !== null) {
       this.markAsDirty(ancestor.node, ancestor.key);
-      ancestor = this.ancestor.get(ancestor.node);
     }
   }
 


### PR DESCRIPTION
Currently, ember-template-recast is getting hung up on deeply nested
trees with lots of changes. It appears markAsDirty(), which should traverse all its parents,
is making a bunch of additional recursions that aren't necessary.

This change updates the logic so it strictly visits its ancestors only.