### PR TITLE
parse: Support `@glimmer/syntax`'s parser options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ const template = `
   baz="stuff"
 }}
 `;
-let ast = templateRecast.parse(template);
+// [optional] a config passed to @glimmer parser (@glimmer/syntax's `preprocess`)
+const config = {};
+let ast = templateRecast.parse(template, config);
 // now you can work with `ast`
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ const template = `
   baz="stuff"
 }}
 `;
-// [optional] a config passed to @glimmer parser (@glimmer/syntax's `preprocess`)
-const config = {};
-let ast = templateRecast.parse(template, config);
+// an optional config passed to @glimmer/syntax parser (`preprocess` method)
+const options = {};
+let ast = templateRecast.parse(template, options);
 // now you can work with `ast`
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ const ParseResult = require('./parse-result');
 
 const PARSE_RESULT_FOR = new WeakMap();
 
-function parse(template) {
-  let result = new ParseResult(template);
+function parse(template, config) {
+  let result = new ParseResult(template, config);
 
   PARSE_RESULT_FOR.set(result.ast, result);
 

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -67,9 +67,6 @@ module.exports = class ParseResult {
   constructor(template, config) {
     let recastOptions = {
       mode: 'codemod',
-      parseOptions: {
-        ignoreStandalone: true,
-      },
     };
     let options = Object.assign({}, config, recastOptions);
     let ast = preprocess(template, options);

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -64,12 +64,9 @@ function fixASTIssues(ast) {
 }
 
 module.exports = class ParseResult {
-  constructor(template, config) {
-    let recastOptions = {
-      mode: 'codemod',
-    };
-    let options = Object.assign({}, config, recastOptions);
-    let ast = preprocess(template, options);
+  constructor(template, options) {
+    let parserOptions = Object.assign({}, options, { mode: 'codemod' });
+    let ast = preprocess(template, parserOptions);
 
     ast = fixASTIssues(ast);
 

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -64,13 +64,15 @@ function fixASTIssues(ast) {
 }
 
 module.exports = class ParseResult {
-  constructor(template) {
-    let ast = preprocess(template, {
+  constructor(template, config) {
+    let recastOptions = {
       mode: 'codemod',
       parseOptions: {
         ignoreStandalone: true,
       },
-    });
+    };
+    let options = Object.assign({}, config, recastOptions);
+    let ast = preprocess(template, options);
 
     ast = fixASTIssues(ast);
 

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -1402,4 +1402,43 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), '<div class="hahah"></div>');
     });
   });
+
+  QUnit.module('parse() has a second argument: `options`', function() {
+    QUnit.test('options is passed to @glimmer/syntax parser', function(assert) {
+      let template = `Text`;
+
+      function plugin() {
+        return {
+          visitor: {
+            TextNode(node) {
+              node.hey = '👋';
+            },
+          },
+        };
+      }
+
+      let config = {
+        plugins: {
+          ast: [plugin],
+        },
+      };
+      let ast = parse(template, config);
+
+      assert.equal(ast.body[0].hey, '👋');
+    });
+
+    // this prevents @glimmer/syntax parser being turned in precompile mode by accident
+    QUnit.test('`mode` option is always set to codemod', function(assert) {
+      // The following template
+      // contains an additional space after the BlockStatement's opening block.
+      // In precompile mode, it would be removed.
+      // In codemod mode it is not.
+      let template = `{{#foo}} \n{{/foo}}`;
+
+      let codemodAst = parse(template);
+      let precompileAst = parse(template, { mode: 'precompile' });
+
+      assert.deepEqual(JSON.stringify(codemodAst), JSON.stringify(precompileAst));
+    });
+  });
 });


### PR DESCRIPTION
With this PR, we'll be able to pass options to the method internally used: `@glimmer/syntax`'s preprocess.

This is a necessary step to use `emberTemplateRecast.parse` method in `ember-template-lint`. Because `template-lint` needs to pass `options.plugins` to the ast parser.

I've done  a spike in template-lint. (only!) two tests are failing.

You could want to review the PR commit by commit.

/cc @rwjblue