### PR TITLE
Fully print if/else-if/else chains (GH #149)

### DIFF
--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -707,8 +707,10 @@ QUnit.module('"real life" smoke tests', function() {
     });
   });
 
-  QUnit.test('If/else-if/else chains with edits early in the chain should be fully printed (GH #149)', function(assert) {
-    let template = `
+  QUnit.test(
+    'If/else-if/else chains with edits early in the chain should be fully printed (GH #149)',
+    function(assert) {
+      let template = `
       {{#if a}}
         {{foo}}
       {{else if b}}
@@ -722,7 +724,7 @@ QUnit.module('"real life" smoke tests', function() {
       {{/if}}
     `;
 
-    let expected = `
+      let expected = `
       {{#if a}}
         {{oof}}
       {{else if b}}
@@ -736,18 +738,19 @@ QUnit.module('"real life" smoke tests', function() {
       {{/if}}
     `;
 
-    let { code } = transform(template, () => {
-      return {
-        MustacheStatement(node) {
-          if (node.path.original === 'foo') {
-            node.path.original = 'oof';
-          }
-        },
-      };
-    });
+      let { code } = transform(template, () => {
+        return {
+          MustacheStatement(node) {
+            if (node.path.original === 'foo') {
+              node.path.original = 'oof';
+            }
+          },
+        };
+      });
 
-    assert.equal(code, expected);
-  });
+      assert.equal(code, expected);
+    }
+  );
 
   QUnit.test('If/else-if/else chains with multiple edits are accurate (GH #149)', function(assert) {
     let template = `
@@ -794,7 +797,7 @@ QUnit.module('"real life" smoke tests', function() {
           if (node.path.original === 'foo') {
             node.path.original = 'oof';
           }
-          if (node.path.original === "quack") {
+          if (node.path.original === 'quack') {
             node.path.original = 'honk';
           }
         },

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -706,4 +706,101 @@ QUnit.module('"real life" smoke tests', function() {
       );
     });
   });
+
+  QUnit.test('If/else-if/else chains with edits early in the chain should be fully printed (GH #149)', function(assert) {
+    let template = `
+      {{#if a}}
+        {{foo}}
+      {{else if b}}
+        {{bar}}
+      {{else if c}}
+        {{baz}}
+      {{else}}
+        {{#if d}}
+          {{qux}}
+        {{/if}}
+      {{/if}}
+    `;
+
+    let expected = `
+      {{#if a}}
+        {{oof}}
+      {{else if b}}
+        {{bar}}
+      {{else if c}}
+        {{baz}}
+      {{else}}
+        {{#if d}}
+          {{qux}}
+        {{/if}}
+      {{/if}}
+    `;
+
+    let { code } = transform(template, () => {
+      return {
+        MustacheStatement(node) {
+          if (node.path.original === 'foo') {
+            node.path.original = 'oof';
+          }
+        },
+      };
+    });
+
+    assert.equal(code, expected);
+  });
+
+  QUnit.test('If/else-if/else chains with multiple edits are accurate (GH #149)', function(assert) {
+    let template = `
+      {{#if a}}
+        {{foo}}
+      {{else if b}}
+        {{bar}}
+      {{else if c}}
+        {{baz}}
+      {{else}}
+        {{#if d}}
+          {{qux}}
+        {{else}}
+          {{quack}}
+        {{/if}}
+      {{/if}}
+      <div class="hello-world">
+        Hello!
+      </div>
+    `;
+
+    let expected = `
+      {{#if a}}
+        {{oof}}
+      {{else if b}}
+        {{bar}}
+      {{else if c}}
+        {{baz}}
+      {{else}}
+        {{#if d}}
+          {{qux}}
+        {{else}}
+          {{honk}}
+        {{/if}}
+      {{/if}}
+      <div class="hello-world">
+        Hello!
+      </div>
+    `;
+
+    let { code } = transform(template, () => {
+      return {
+        MustacheStatement(node) {
+          if (node.path.original === 'foo') {
+            node.path.original = 'oof';
+          }
+          if (node.path.original === "quack") {
+            node.path.original = 'honk';
+          }
+        },
+      };
+    });
+
+    assert.equal(code, expected);
+  });
 });


### PR DESCRIPTION
For chained nodes, look at the body of the inverse (not the inverse
itself) for an accurate loc identifier that captures the complete
inverse chain.

Note: I'm not entirely convinced this is the best way to solve this. Are there any pitfalls with this approach I might be missing? Should this code traverse and process each inverse node instead?

Fixes #149 