### PR TITLE
chore: Remove overriden option

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -67,9 +67,6 @@ module.exports = class ParseResult {
   constructor(template) {
     let ast = preprocess(template, {
       mode: 'codemod',
-      parseOptions: {
-        ignoreStandalone: true,
-      },
     });
 
     ast = fixASTIssues(ast);


### PR DESCRIPTION
In `@glimmer/syntax` package, `parseOptions` is always set to `{ ignoreStandalone: true }`  when mode is `codemod`.

See https://github.com/ember-template-lint/ember-template-recast/pull/151 for further details.