### PR TITLE
fix: Make it possible to annotate nodes

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -989,12 +989,14 @@ module.exports = class ParseResult {
         );
     }
 
-    if (dirtyFields.size > 0) {
-      throw new Error(
-        `ember-template-recast could not handle the mutations of \`${Array.from(
-          dirtyFields
-        )}\` on ${original.type}`
-      );
+    for (let field of dirtyFields.values()) {
+      if (field in Object.keys(original)) {
+        throw new Error(
+          `ember-template-recast could not handle the mutations of \`${Array.from(
+            dirtyFields
+          )}\` on ${original.type}`
+        );
+      }
     }
 
     return output.join('');

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -1051,6 +1051,15 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), '{{#foo-bar}}Goodbye{{/foo-bar}}');
     });
 
+    QUnit.test('annotating an "else if" node', function(assert) {
+      let template = '{{#if foo}}{{else if bar}}{{else}}{{/if}}';
+
+      let ast = parse(template);
+      ast.body[0].inverse.body[0]._isElseIfBlock = true;
+
+      assert.equal(print(ast), '{{#if foo}}{{else if bar}}{{else}}{{/if}}');
+    });
+
     QUnit.test('add block param (when none existed)', function(assert) {
       let template = `{{#foo-bar}}{{/foo-bar}}`;
 


### PR DESCRIPTION
I've added a test that fails with this error:
```
  stack: Error: ember-template-recast could not handle the mutations of `_isElseIfBlock` on BlockStatement
    at ParseResult.print (d:\a\ember-template-recast\ember-template-recast\src\parse-result.js:993:13)
    at ParseResult.print (d:\a\ember-template-recast\ember-template-recast\src\parse-result.js:805:38)
    at ast.body.map.node (d:\a\ember-template-recast\ember-template-recast\src\parse-result.js:366:52)
    at Array.map (<anonymous>)
    at ParseResult.print (d:\a\ember-template-recast\ember-template-recast\src\parse-result.js:366:35)
    at print (d:\a\ember-template-recast\ember-template-recast\src\index.js:16:22)
    at Object.<anonymous> (d:\a\ember-template-recast\ember-template-recast\tests\parse-result-test.js:1060:20)
    at runTest (d:\a\ember-template-recast\ember-template-recast\node_modules\qunit\qunit\qunit.js:3041:30)
    at Test.run (d:\a\ember-template-recast\ember-template-recast\node_modules\qunit\qunit\qunit.js:3027:6)
    at d:\a\ember-template-recast\ember-template-recast\node_modules\qunit\qunit\qunit.js:3258:12
```

It looks impossible to annotate an `else if` node right now. The type of the node is BlockStatement.

This is an issue I ran into while switching to use `ember-template-recast` in `ember-template-lint`. The rule involved there is: `lint-block-indentation`.

I'm not quite sure in which direction to go. I see two options: 1/ refactor the visitor on `ember-template-lint` side to annotate the node in a different way; 2/ fix the annotation here in `ember-template-recast`. I would go for the second option, but may you confirm @rwjblue?

EDIT: added the error stacktrace