### PR TITLE
Fix transform documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,12 @@ The plugin argument has roughly the following interface:
 
 ```ts
 export interface ASTPluginBuilder {
-  (env: ASTPluginEnvironment): ASTPlugin;
+  (env: ASTPluginEnvironment): NodeVisitor;
 }
 
 export interface ASTPluginEnvironment {
   meta?: any;
   syntax: Syntax;
-}
-
-export interface ASTPlugin {
-  name: string;
-  visitor: NodeVisitor;
 }
 
 export interface Syntax {


### PR DESCRIPTION
An alternative approach would be to modify ´transform´ to match the documentation. It would make the switch to template-recast in ember-template-lint easier. But it would be quite a breaking change 🤓.