### PR TITLE
Ensure templates with whitespace control are codemoded properly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "qunit tests/**/*-test.js"
   },
   "dependencies": {
-    "@glimmer/syntax": "^0.42.2",
+    "@glimmer/syntax": "^0.43.0",
     "async-promise-queue": "^1.0.5",
     "colors": "^1.3.3",
     "commander": "^3.0.0",

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -1003,12 +1003,12 @@ QUnit.module('ember-template-recast', function() {
     QUnit.test(
       'adding child to end of inverse preserves whitespace and whitespace control when program is also present',
       function(assert) {
-        let template = `{{#foo-bar}}Goodbye{{~ else ~}}Hello{{/foo-bar}}`;
+        let template = `{{#foo-bar}}Goodbye\n  {{~ else ~}} Hello{{/foo-bar}}`;
 
         let ast = parse(template);
         ast.body[0].inverse.body.push(builders.text(' world!'));
 
-        assert.equal(print(ast), '{{#foo-bar}}Goodbye{{~ else ~}}Hello world!{{/foo-bar}}');
+        assert.equal(print(ast), '{{#foo-bar}}Goodbye\n  {{~ else ~}} Hello world!{{/foo-bar}}');
       }
     );
 

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -487,6 +487,33 @@ QUnit.module('"real life" smoke tests', function() {
       );
     });
 
+    QUnit.test('`if` branch containing whitespace controls', function(assert) {
+      let template = `
+        {{#if foo~}}
+          {{foo}}
+        {{/if}}
+      `;
+
+      let expected = `
+        {{#if foo~}}
+          {{oof}}
+        {{/if}}
+      `;
+
+      let { code } = transform(template, () => {
+        return {
+          MustacheStatement(node) {
+            node.path.original = node.path.original
+              .split('')
+              .reverse()
+              .join('');
+          },
+        };
+      });
+
+      assert.equal(code, expected);
+    });
+
     QUnit.test('collapsing lines (full line replacment)', function(assert) {
       let template = stripIndent`
         here

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,25 +26,25 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@glimmer/interfaces@^0.42.2":
-  version "0.42.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.42.2.tgz#9cf8d6f8f5eee6bfcfa36919ca68ae716e1f78db"
-  integrity sha512-7LOuQd02cxxNNHChzdHMAU8/qOeQvTro141CU5tXITP7z6aOv2D2gkFdau97lLQiVxezGrh8J7h8GCuF7TEqtg==
+"@glimmer/interfaces@^0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.43.0.tgz#a7a38c2476f87d68d6dc894840df17bc8b92de33"
+  integrity sha512-rWu6WHVo6tuFFOKOSJWAWsFfXZgkdnKDnvhl3tAb20njW/0uBZ2nx7GZ3lImvBeG0HoxyzYA7pD299ps03TemA==
 
-"@glimmer/syntax@^0.42.2":
-  version "0.42.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.42.2.tgz#89bb3cb787285b84665dc0d8907d94b008e5be9a"
-  integrity sha512-SR26SmF/Mb5o2cc4eLHpOyoX5kwwXP4KRhq4fbWfrvan74xVWA38PLspPCzwGhyVH/JsE7tUEPMjSo2DcJge/Q==
+"@glimmer/syntax@^0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.43.0.tgz#d6e30c857c575eeac25b3f7ffab2cfee43685726"
+  integrity sha512-qJqzcbF9lgdLE5A1rCwTs0CLnblNK95Y6MMLNsvJEJA7j1Gx50ySoUZ5HTk86Z5auhDgvInhuufyGtdojSIMSg==
   dependencies:
-    "@glimmer/interfaces" "^0.42.2"
-    "@glimmer/util" "^0.42.2"
+    "@glimmer/interfaces" "^0.43.0"
+    "@glimmer/util" "^0.43.0"
     handlebars "^4.0.13"
     simple-html-tokenizer "^0.5.8"
 
-"@glimmer/util@^0.42.2":
-  version "0.42.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.2.tgz#9ca1631e42766ea6059f4b49d0bdfb6095aad2c4"
-  integrity sha512-Heck0baFSaWDanCYtmOcLeaz7v+rSqI8ovS7twrp2/FWEteb3Ze5sWQ2BEuSAG23L/k/lzVwYM/MY7ZugxBpaA==
+"@glimmer/util@^0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.43.0.tgz#dd28cd1a233c25427032437b9050c6fa6d098e2c"
+  integrity sha512-RtjHU8/rhysOugu+Q0j6dQ3G67J4h45tQgKPEwVPxu8P+hqijqnz/lBLxTdVg/1zKmlqUkyngTr8H4Jpg2yF/g==
 
 "@iarna/toml@2.2.3":
   version "2.2.3"


### PR DESCRIPTION
This updates to `@glimmer/syntax@0.43.0` which includes https://github.com/glimmerjs/glimmer-vm/pull/983.

Closes #156
Fixes #155