### PR TITLE
Add `.gitattributes` file to better simulate a Windows environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
Attempting to reproduce https://github.com/ember-codemods/ember-angle-brackets-codemod/issues/160 on Windows CI.