### PR TITLE
Fix issue with mutation of `ElementNode`'s attributes when the first attribute value is `=""`

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -1,5 +1,5 @@
 const { preprocess, print: _print, traverse } = require('@glimmer/syntax');
-const { sortByLoc } = require('./utils');
+const { sortByLoc, sourceForLoc } = require('./utils');
 
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const leadingWhitespace = /(^\s+)/;
@@ -157,39 +157,7 @@ module.exports = class ParseResult {
    in a proxy).
   */
   sourceForLoc(loc) {
-    if (!loc) {
-      return;
-    }
-
-    let firstLine = loc.start.line - 1;
-    let lastLine = loc.end.line - 1;
-    let currentLine = firstLine - 1;
-    let firstColumn = loc.start.column;
-    let lastColumn = loc.end.column;
-    let string = [];
-    let line;
-
-    while (currentLine < lastLine) {
-      currentLine++;
-      // for templates that are completely empty the outer Template loc is line
-      // 0, column 0 for both start and end defaulting to empty string prevents
-      // more complicated logic below
-      line = this.source[currentLine] || '';
-
-      if (currentLine === firstLine) {
-        if (firstLine === lastLine) {
-          string.push(line.slice(firstColumn, lastColumn));
-        } else {
-          string.push(line.slice(firstColumn));
-        }
-      } else if (currentLine === lastLine) {
-        string.push(line.slice(0, lastColumn));
-      } else {
-        string.push(line);
-      }
-    }
-
-    return string.join('');
+    return sourceForLoc(this.source, loc);
   }
 
   markAsDirty(node, property) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,39 @@
+function sourceForLoc(sourceLines, loc) {
+  if (!loc) {
+    return;
+  }
+
+  let firstLine = loc.start.line - 1;
+  let lastLine = loc.end.line - 1;
+  let currentLine = firstLine - 1;
+  let firstColumn = loc.start.column;
+  let lastColumn = loc.end.column;
+  let string = [];
+  let line;
+
+  while (currentLine < lastLine) {
+    currentLine++;
+    // for templates that are completely empty the outer Template loc is line
+    // 0, column 0 for both start and end defaulting to empty string prevents
+    // more complicated logic below
+    line = sourceLines[currentLine] || '';
+
+    if (currentLine === firstLine) {
+      if (firstLine === lastLine) {
+        string.push(line.slice(firstColumn, lastColumn));
+      } else {
+        string.push(line.slice(firstColumn));
+      }
+    } else if (currentLine === lastLine) {
+      string.push(line.slice(0, lastColumn));
+    } else {
+      string.push(line);
+    }
+  }
+
+  return string.join('');
+}
+
 function isSynthetic(node) {
   if (node && node.loc) {
     return node.loc.source === '(synthetic)';
@@ -50,4 +86,5 @@ module.exports = {
   sortByLoc,
   compact,
   compactJoin,
+  sourceForLoc,
 };

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -833,4 +833,24 @@ QUnit.module('"real life" smoke tests', function() {
 
     assert.equal(code, expected);
   });
+
+  QUnit.test('mustache param slicing (GH #149)', function(assert) {
+    let template = `
+      <SomeComponent
+        class=""
+        @foo=42
+        @bar={{action this.baz}}
+      />
+    `;
+
+    let expected = template;
+
+    let { code } = transform(template, () => ({
+      MustacheStatement(node) {
+        node.params = node.params.slice();
+      },
+    }));
+
+    assert.equal(code, expected);
+  });
 });


### PR DESCRIPTION
see https://github.com/ember-template-lint/ember-template-recast/issues/180

/cc @rwjblue 