### PR TITLE
Ensure attributes, params, hash are only joined with whitespace.

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -251,6 +251,12 @@ module.exports = class ParseResult {
           joinWith = ' ';
         }
 
+        if (joinWith.trim() !== '') {
+          // if the autodetection above resulted in some non whitespace
+          // values, reset to `' '`
+          joinWith = ' ';
+        }
+
         nodeInfo.hashSource = ast.hash.pairs
           .map(pair => {
             return this.print(pair);
@@ -277,6 +283,12 @@ module.exports = class ParseResult {
       } else if (nodeInfo.hadHash) {
         joinWith = nodeInfo.postParamsWhitespace;
       } else {
+        joinWith = ' ';
+      }
+
+      if (joinWith.trim() !== '') {
+        // if the autodetection above resulted in some non whitespace
+        // values, reset to `' '`
         joinWith = ' ';
       }
       nodeInfo.paramsSource = ast.params.map(param => this.print(param)).join(joinWith);
@@ -372,6 +384,12 @@ module.exports = class ParseResult {
               start: originalOpenParts[0].loc.end,
               end: originalOpenParts[1].loc.start,
             });
+          }
+
+          if (joinOpenPartsWith.trim() !== '') {
+            // if the autodetection above resulted in some non whitespace
+            // values, reset to `' '`
+            joinOpenPartsWith = ' ';
           }
 
           let openPartsSource = originalOpenParts


### PR DESCRIPTION
A bug was fixed recently that was caused by improperly detecting the join value for attributes. That issue was corrected (along with tests to ensure no regressions), but upon reflection it seemed completely bizarre that we would _ever_ allow the autodetected join value to be something other than whitespace.

This commit inserts a fallback to ensure that if we ever do happen to auto-detect a non-whitespace value as the join value, that we instead use `' '`. There are no known scenarios where we can actually **hit** this code, but it still seems reasonable to add in order to make this a bit safter by default.