### PR TITLE
Add basic type declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "src/"
   ],
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "bin": "bin/ember-template-recast.js",
   "scripts": {
     "changelog": "lerna-changelog",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,14 @@
+import { Walker, AST, NodeVisitor, builders, traverse } from '@glimmer/syntax';
+
+interface PluginEnv {
+  builders: typeof builders;
+  parse: typeof parse;
+  print: typeof print;
+  traverse: typeof traverse;
+  Walker: Walker;
+}
+
+export { traverse, builders } from '@glimmer/syntax';
+export declare function parse(template: string): AST.Template;
+export declare function print(ast: AST.Node): string;
+export declare function transform(template: string | AST.Node, plugin: (env: PluginEnv) => NodeVisitor): { ast: AST.Node, code: string };


### PR DESCRIPTION
This PR adds a basic TypeScript type declaration file to the project, reexporting all of the relevant types from `@glimmer/syntax`. This allows us to use auto-completion and type checking for code using ember-template-recast. 🎉 

<img width="588" alt="Bildschirmfoto 2019-12-23 um 05 03 52" src="https://user-images.githubusercontent.com/141300/71335192-cff0fb00-2541-11ea-866b-52d6625461f6.png">

<img width="618" alt="Bildschirmfoto 2019-12-23 um 05 05 03" src="https://user-images.githubusercontent.com/141300/71335193-cff0fb00-2541-11ea-8e8e-895709f6e27f.png">
