### PR TITLE
Expose metadata (isValueless / quoteType) on AttrNode's

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -42,7 +42,8 @@ function fixASTIssues(sourceLines, ast) {
   traverse(ast, {
     AttrNode(node) {
       let source = sourceForLoc(sourceLines, node.loc);
-      let isValueless = !source.includes('=');
+      let [, , , equals, , quote] = source.match(attrNodeParts);
+      let isValueless = !equals;
 
       // TODO: manually working around https://github.com/glimmerjs/glimmer-vm/pull/953
       if (isValueless && node.value.type === 'TextNode' && node.value.chars === '') {
@@ -51,6 +52,9 @@ function fixASTIssues(sourceLines, ast) {
         node.loc.end.line = node.loc.start.line;
         node.loc.end.column = node.loc.start.column + node.name.length;
       }
+
+      node.isValueless = isValueless;
+      node.quoteType = quote ? quote : null;
     },
     TextNode(node, path) {
       let source = sourceForLoc(sourceLines, node.loc);

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -1200,6 +1200,88 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), '<Foo bar="{{foo}} static {{bar}}" />');
     });
 
+    QUnit.test(
+      'can determine if an AttrNode was valueless (required by ember-template-lint)',
+      function(assert) {
+        assert.strictEqual(
+          parse(`<Foo bar={{foo}} />`).body[0].attributes[0].isValueless,
+          false,
+          'MustacheStatement attribute value'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar="foo {{bar}}" />`).body[0].attributes[0].isValueless,
+          false,
+          'ConcatStatement attribute value'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar='foo {{bar}}' />`).body[0].attributes[0].isValueless,
+          false,
+          'ConcatStatement attribute value'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar="foo" />`).body[0].attributes[0].isValueless,
+          false,
+          'TextNode attribute value'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar='foo' />`).body[0].attributes[0].isValueless,
+          false,
+          'TextNode attribute value'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar=foo />`).body[0].attributes[0].isValueless,
+          false,
+          'TextNode attribute value'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar />`).body[0].attributes[0].isValueless,
+          true,
+          'valueless attribute'
+        );
+      }
+    );
+
+    QUnit.test(
+      'can determine type of quotes used from AST (required by ember-template-lint)',
+      function(assert) {
+        assert.strictEqual(
+          parse(`<Foo bar={{foo}} />`).body[0].attributes[0].quoteType,
+          null,
+          'mustache attribute values are `null`'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar="foo {{bar}}" />`).body[0].attributes[0].quoteType,
+          `"`,
+          'ConcatStatement attribute values show double quotes'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar='foo {{bar}}' />`).body[0].attributes[0].quoteType,
+          `'`,
+          'ConcatStatement attribute values show single quotes'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar="foo" />`).body[0].attributes[0].quoteType,
+          `"`,
+          'TextNode attribute values show double quotes'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar='foo' />`).body[0].attributes[0].quoteType,
+          `'`,
+          'TextNode attribute values show single quotes'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar=foo />`).body[0].attributes[0].quoteType,
+          null,
+          'TextNode attribute values for quoteless'
+        );
+        assert.strictEqual(
+          parse(`<Foo bar />`).body[0].attributes[0].quoteType,
+          null,
+          'valueless attribute'
+        );
+      }
+    );
+
     QUnit.test('renaming valueless attribute', function(assert) {
       let template = '<Foo data-bar />';
 


### PR DESCRIPTION
The fixes introduced in a589561e caused issues for ember-template-lint@2.x branch (which uses ember-template-recast as its parser). The underlying reason for the issue is that ember-template-lint was _basically_ relying on the bug fixed (e.g. it was looking at `AttrNode`'s `.value` and doing `sourceForLoc` on that node, then checking if it starts with a quote) .

In order for those ember-template-lint rules to function (`quotes` and `no-quoteless-attribute`) they need to know if a given attribute had a value (aka was it `<div data-test-blah></div>` vs `<div data-test-blah="thing"></div>`) and what type of quotes were used (single, double, none, etc).

This adds to the existing `AttrNode` interface, such that it is:

```ts
export interface AttrNode extends BaseNode {
  type: 'AttrNode';
  name: string;
  value: TextNode | MustacheStatement | ConcatStatement;
  isValueless: boolean;
  quoteType: '"' | "'" | null;
}
```