### PR TITLE
Ensure updating self-closing ElementNode preserves trailing whitespace.

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -388,16 +388,23 @@ module.exports = class ParseResult {
             .concat(original.attributes, original.modifiers, original.comments)
             .sort(sortByLoc);
 
-          let postTagWhitespace =
-            originalOpenParts.length > 0
-              ? this.sourceForLoc({
-                  start: {
-                    line: original.loc.start.line,
-                    column: original.loc.start.column + 1 /* < */ + original.tag.length,
-                  },
-                  end: originalOpenParts[0].loc.start,
-                })
-              : '';
+          let postTagWhitespace;
+          if (originalOpenParts.length > 0) {
+            postTagWhitespace = this.sourceForLoc({
+              start: {
+                line: original.loc.start.line,
+                column: original.loc.start.column + 1 /* < */ + original.tag.length,
+              },
+              end: originalOpenParts[0].loc.start,
+            });
+          } else if (selfClosing) {
+            postTagWhitespace = nodeInfo.source.substring(
+              openSource.length,
+              nodeInfo.source.length - 2
+            );
+          } else {
+            postTagWhitespace = '';
+          }
 
           let joinOpenPartsWith = ' ';
           if (originalOpenParts.length > 1) {
@@ -488,6 +495,7 @@ module.exports = class ParseResult {
 
             if (selfClosing) {
               closeOpen = `>`;
+              postTagWhitespace = '';
               closeSource = `</${ast.tag}>`;
               ast.selfClosing = false;
             }

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -133,6 +133,14 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), '<Qux bar="baz"/>');
     });
 
+    QUnit.test('rename self-closing element tagname with trailing whitespace', function(assert) {
+      let ast = parse('<Foo />');
+
+      ast.body[0].tag = 'Qux';
+
+      assert.equal(print(ast), '<Qux />');
+    });
+
     QUnit.test('adding attribute when none originally existed', function(assert) {
       let template = stripIndent`
       <div></div>`;


### PR DESCRIPTION
Previously, when transforming:

```hbs
<Foo />
```

By setting the tag (e.g. `node.tag = 'Bar';`), we would remove the trailing whitespace and emit:

```hbs
<Bar/>
```

This ensures that the output is now:

```hbs
<Bar />
```