### PR TITLE
Fix issue when swapping ElementNode from self closing with attributes to block.

### DIFF
--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -495,9 +495,16 @@ module.exports = class ParseResult {
 
             if (selfClosing) {
               closeOpen = `>`;
-              postTagWhitespace = '';
               closeSource = `</${ast.tag}>`;
               ast.selfClosing = false;
+
+              if (originalOpenParts.length === 0 && postTagWhitespace === ' ') {
+                postTagWhitespace = '';
+              }
+
+              if (originalOpenParts.length > 0 && postPartsWhitespace === ' ') {
+                postPartsWhitespace = '';
+              }
             }
 
             dirtyFields.delete('children');

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -141,13 +141,43 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), '<Qux />');
     });
 
-    QUnit.test('Convert self-closing element with attributes to block element', function(assert) {
+    QUnit.test(
+      'Rename tag and convert from self-closing with attributes to block element',
+      function(assert) {
+        let ast = parse('<Foo bar="baz" />');
+
+        ast.body[0].tag = 'Qux';
+        ast.body[0].children = [builders.text('bay')];
+
+        assert.equal(print(ast), '<Qux bar="baz">bay</Qux>');
+      }
+    );
+
+    QUnit.test('convert from self-closing with attributes to block element', function(assert) {
       let ast = parse('<Foo bar="baz" />');
 
-      ast.body[0].tag = 'Qux';
       ast.body[0].children = [builders.text('bay')];
 
-      assert.equal(print(ast), '<Qux bar="baz">bay</Qux>');
+      assert.equal(print(ast), '<Foo bar="baz">bay</Foo>');
+    });
+
+    QUnit.test(
+      'convert from self-closing with specially spaced attributes to block element',
+      function(assert) {
+        let ast = parse('<Foo\n  bar="baz"\n />');
+
+        ast.body[0].children = [builders.text('bay')];
+
+        assert.equal(print(ast), '<Foo\n  bar="baz"\n >bay</Foo>');
+      }
+    );
+
+    QUnit.test('Convert self-closing element with modifiers block element', function(assert) {
+      let ast = parse('<Foo {{on "click" this.doSomething}} />');
+
+      ast.body[0].children = [builders.text('bay')];
+
+      assert.equal(print(ast), '<Foo {{on "click" this.doSomething}}>bay</Foo>');
     });
 
     QUnit.test('adding attribute when none originally existed', function(assert) {

--- a/tests/parse-result-test.js
+++ b/tests/parse-result-test.js
@@ -141,6 +141,15 @@ QUnit.module('ember-template-recast', function() {
       assert.equal(print(ast), '<Qux />');
     });
 
+    QUnit.test('Convert self-closing element with attributes to block element', function(assert) {
+      let ast = parse('<Foo bar="baz" />');
+
+      ast.body[0].tag = 'Qux';
+      ast.body[0].children = [builders.text('bay')];
+
+      assert.equal(print(ast), '<Qux bar="baz">bay</Qux>');
+    });
+
     QUnit.test('adding attribute when none originally existed', function(assert) {
       let template = stripIndent`
       <div></div>`;


### PR DESCRIPTION
The original fix (that landed in 4.1.1) assumed that it was _always_ acceptable to remove the `postTagWhitespace` when moving from self closing to having children. Unfortunately, that only worked because the specific test cases added didn't use attributes (or block params).

This fix builds on a test provided by [@lukemelia](https://github.com/lukemelia) and adds a few more tests (for various combos of other argument types) and ensures that the resulting whitespace is "intuitive" (yes, I know this is subjective, but I made the changes so I get to say it is intuitive :P ).

Closes #250 (thanks @lukemelia!)