### PR TITLE
Update link to glimmer builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export interface Syntax {
 ```
 
 The list of known builders on the `env.syntax.builders` are [found
-here](https://github.com/glimmerjs/glimmer-vm/blob/f765e14a86500bb5cdc1edc90297e7150ed8b44d/packages/%40glimmer/syntax/lib/builders.ts#L547-L578).
+here](https://github.com/glimmerjs/glimmer-vm/blob/v0.50.4/packages/%40glimmer/syntax/lib/builders.ts#L547-L578).
 
 Example:
 ```js

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export interface Syntax {
 ```
 
 The list of known builders on the `env.syntax.builders` are [found
-here](https://github.com/glimmerjs/glimmer-vm/blob/master/packages/@glimmer/syntax/lib/builders.ts#L308-L337)
+here](https://github.com/glimmerjs/glimmer-vm/blob/f765e14a86500bb5cdc1edc90297e7150ed8b44d/packages/%40glimmer/syntax/lib/builders.ts#L547-L578).
 
 Example:
 ```js


### PR DESCRIPTION
The previous link was outdated due to code changing on master over the past few years.