### PR TITLE
Improve whitespace preservation around dirty attributes / comments / modifiers

### DIFF
--- a/__tests__/parse-result-test.js
+++ b/__tests__/parse-result-test.js
@@ -217,8 +217,7 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(stripIndent`
       <div
         data-foo='lol'
-        data-bar=hahaha
-        data-test="wheee"
+        data-bar=hahaha data-test="wheee"
       ></div>`);
     });
 
@@ -513,8 +512,7 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(stripIndent`
         <div data-foo
          data-bar="lol"
-              some-other-thing={{haha}}
-        foo-foo="wheee">
+              some-other-thing={{haha}} foo-foo="wheee">
         </div>
       `);
     });

--- a/__tests__/parse-result-test.js
+++ b/__tests__/parse-result-test.js
@@ -498,6 +498,26 @@ describe('ember-template-recast', function () {
         <Foo></Foo>
       `);
     });
+
+    test('adding a new attribute to an ElementNode while preserving the existing whitespaces', function () {
+      let template = stripIndent`
+        <div data-foo
+         data-bar="lol"
+              some-other-thing={{haha}}>
+        </div>
+      `;
+
+      let ast = parse(template);
+      ast.body[0].attributes.push(builders.attr('foo-foo', builders.string('wheee')));
+
+      expect(print(ast)).toEqual(stripIndent`
+        <div data-foo
+         data-bar="lol"
+              some-other-thing={{haha}}
+        foo-foo="wheee">
+        </div>
+      `);
+    });
   });
 
   describe('MustacheStatement', function () {

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -406,23 +406,26 @@ module.exports = class ParseResult {
             postTagWhitespace = '';
           }
 
-          let joinOpenPartsWith = ' ';
-          if (originalOpenParts.length > 1) {
-            joinOpenPartsWith = this.sourceForLoc({
-              start: originalOpenParts[0].loc.end,
-              end: originalOpenParts[1].loc.start,
+          let openPartsSource = originalOpenParts.reduce((acc, part, index, parts) => {
+            let partSource = this.sourceForLoc(part.loc);
+
+            if (index === parts.length - 1) {
+              return acc + partSource;
+            }
+
+            let joinPartWith = this.sourceForLoc({
+              start: parts[index].loc.end,
+              end: parts[index + 1].loc.start,
             });
-          }
 
-          if (joinOpenPartsWith.trim() !== '') {
-            // if the autodetection above resulted in some non whitespace
-            // values, reset to `' '`
-            joinOpenPartsWith = ' ';
-          }
+            if (joinPartWith.trim() !== '') {
+              // if the autodetection above resulted in some non whitespace
+              // values, reset to `' '`
+              joinPartWith = ' ';
+            }
 
-          let openPartsSource = originalOpenParts
-            .map((part) => this.sourceForLoc(part.loc))
-            .join(joinOpenPartsWith);
+            return acc + partSource + joinPartWith;
+          }, '');
 
           let postPartsWhitespace = '';
           if (originalOpenParts.length > 0) {
@@ -517,6 +520,19 @@ module.exports = class ParseResult {
           ) {
             let openParts = [].concat(ast.attributes, ast.modifiers, ast.comments).sort(sortByLoc);
 
+            let joinOpenPartsWith = ' ';
+            if (originalOpenParts.length > 1) {
+              joinOpenPartsWith = this.sourceForLoc({
+                start: originalOpenParts[0].loc.end,
+                end: originalOpenParts[1].loc.start,
+              });
+            }
+
+            if (joinOpenPartsWith.trim() !== '') {
+              // if the autodetection above resulted in some non whitespace
+              // values, reset to `' '`
+              joinOpenPartsWith = ' ';
+            }
             openPartsSource = openParts.map((part) => this.print(part)).join(joinOpenPartsWith);
 
             if (originalOpenParts.length === 0) {

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -520,20 +520,26 @@ module.exports = class ParseResult {
           ) {
             let openParts = [].concat(ast.attributes, ast.modifiers, ast.comments).sort(sortByLoc);
 
-            let joinOpenPartsWith = ' ';
-            if (originalOpenParts.length > 1) {
-              joinOpenPartsWith = this.sourceForLoc({
-                start: originalOpenParts[0].loc.end,
-                end: originalOpenParts[1].loc.start,
-              });
-            }
+            openPartsSource = openParts.reduce((acc, part, index, parts) => {
+              let partSource = this.print(part);
 
-            if (joinOpenPartsWith.trim() !== '') {
-              // if the autodetection above resulted in some non whitespace
-              // values, reset to `' '`
-              joinOpenPartsWith = ' ';
-            }
-            openPartsSource = openParts.map((part) => this.print(part)).join(joinOpenPartsWith);
+              if (index === parts.length - 1) {
+                return acc + partSource;
+              }
+
+              let joinPartWith = this.sourceForLoc({
+                start: parts[index].loc.end,
+                end: parts[index + 1].loc.start,
+              });
+
+              if (joinPartWith === '' || joinPartWith.trim() !== '') {
+                // if the autodetection above resulted in some non whitespace
+                // values, reset to `' '`
+                joinPartWith = ' ';
+              }
+
+              return acc + partSource + joinPartWith;
+            }, '');
 
             if (originalOpenParts.length === 0) {
               postTagWhitespace = ' ';


### PR DESCRIPTION
This PR proposes to improve whitespace preservation around dirty attributes in `ElementNode`s.

If we append `foo-foo="wheee"` to this div's attributes:
```js
<div data-foo
 data-bar="lol"
          some-other-thing={{haha}}>
</div>
```
**on master:**
```js
<div data-foo
 data-bar="lol"
 some-other-thing={{haha}}
 foo-foo="wheee">
</div>
```
**with this PR:**
```js
<div data-foo
 data-bar="lol"
          some-other-thing={{haha}} foo-foo="wheee">
</div>
```
Supersedes https://github.com/ember-template-lint/ember-template-recast/pull/265