### PR TITLE
Preserve formatting when switching a template's body

### DIFF
--- a/__tests__/smoke-test.js
+++ b/__tests__/smoke-test.js
@@ -825,7 +825,7 @@ describe('"real life" smoke tests', function () {
     expect(code).toEqual('ZOMG other things here');
   });
 
-  test('cannot replace whole template (formatting is lost)', function () {
+  test('preserve formatting when replacing a whole template', function () {
     let template = `<div data-foo
  data-bar="lol"
       some-other-thing={{haha}}>

--- a/__tests__/smoke-test.js
+++ b/__tests__/smoke-test.js
@@ -824,4 +824,28 @@ describe('"real life" smoke tests', function () {
 
     expect(code).toEqual('ZOMG other things here');
   });
+
+  test('cannot replace whole template (formatting is lost)', function () {
+    let template = `<div data-foo
+ data-bar="lol"
+      some-other-thing={{haha}}>
+</div>`;
+    let replacement = `<div
+data-foo
+data-bar="lol"
+some-other-thing={{haha}}></div>`;
+
+    let { code } = transform(template, (env) => {
+      return {
+        Program: {
+          exit(node) {
+            let ast = env.syntax.parse(replacement);
+            node.body = ast.body;
+          },
+        },
+      };
+    });
+
+    expect(code).toEqual(replacement);
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@ const { traverse, builders, Walker } = require('@glimmer/syntax');
 const ParseResult = require('./parse-result');
 
 const PARSE_RESULT_FOR = new WeakMap();
+const NODES_INFO = new Map();
 
 function parse(template) {
-  let result = new ParseResult(template);
+  let result = new ParseResult(template, NODES_INFO);
 
   PARSE_RESULT_FOR.set(result.ast, result);
 

--- a/src/parse-result.js
+++ b/src/parse-result.js
@@ -86,7 +86,7 @@ function fixASTIssues(sourceLines, ast) {
 }
 
 module.exports = class ParseResult {
-  constructor(template) {
+  constructor(template, nodesInfo) {
     let ast = preprocess(template, {
       mode: 'codemod',
     });
@@ -97,7 +97,7 @@ module.exports = class ParseResult {
     this.source = source;
     this._originalAst = ast;
 
-    this.nodeInfo = new Map();
+    this.nodeInfo = nodesInfo;
     this.ancestor = new Map();
     this.dirtyFields = new Map();
 


### PR DESCRIPTION
This PR adds a failing test for the following scenario: we replace a template’s body with another template’s body. And the formatting of the replacement is not kept.

It also proposes a fix.

I have tested this PR along with https://github.com/ember-template-lint/ember-template-lint-plugin-prettier/pull/78 in a large codebase. And —fix option works there. 🎉

Supersedes the run around: https://github.com/ember-template-lint/ember-template-recast/pull/265