### PR TITLE
feature(ElementNode): Attributes order could be changed through the ast?

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -49,6 +49,23 @@ describe('ember-template-recast', function () {
       }}`);
   });
 
+  test('basic parse -> mutation: attributes order can be changed -> print', function () {
+    let template = stripIndent`
+      <div ...attributes class="foo"></div>
+      <div class="foo" ...attributes></div>
+    `;
+    let ast = parse(template);
+    let { body } = ast;
+
+    body[0].attributes = body[0].attributes.reverse();
+    body[2].attributes = body[2].attributes.reverse();
+
+    expect(print(ast)).toEqual(stripIndent`
+      <div class="foo" ...attributes></div>
+      <div ...attributes class="foo"></div>
+    `);
+  });
+
   test('basic parse -> mutation -> print: preserves HTML entities', function () {
     let template = stripIndent`<div>&nbsp;</div>`;
     let ast = parse(template);


### PR DESCRIPTION
For discussion purpose, this PR adds a failing test for a possible feature.

It could be possible to change the attributes order through the ast?