### PR TITLE
performance: Fix memory heap issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { traverse, builders, Walker } = require('@glimmer/syntax');
 const ParseResult = require('./parse-result');
 
 const PARSE_RESULT_FOR = new WeakMap();
-const NODES_INFO = new Map();
+const NODES_INFO = new WeakMap();
 
 function parse(template) {
   let result = new ParseResult(template, NODES_INFO);


### PR DESCRIPTION
## A performance issue

Described in (and would close) https://github.com/ember-template-lint/ember-template-recast/issues/352

## A fix

There is no need to use a Map here. A WeakMap would do it since every `nodeInfo` is an object.

Désolé again @rwjblue 

## Stats

I manually ran it against a codebase. The memory heap went down from ~633MB to 49MB. Pinning to ember-template-recast@4.1.4, the memory heap is 67MB.

In a perfect world, we would add a performance test to assert we're not consuming too much memory... But it seems complex to implement.