### PR TITLE
Add a failing test to show textarea doesn't retain whitespace

### DIFF
--- a/__tests__/parse-result-test.js
+++ b/__tests__/parse-result-test.js
@@ -1193,6 +1193,21 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual('<Foo \n  bar = {{ bar }} />');
     });
 
+    test('mutations retain textarea whitespace formatting', function () {
+      let template = stripIndent`
+        <textarea name="foo">
+        </textarea>
+      `;
+
+      let ast = parse(template);
+      ast.body[0].attributes[0].value.chars = 'bar';
+
+      expect(print(ast)).toEqual(stripIndent`
+        <textarea name="bar">
+        </textarea>
+      `);
+    });
+
     test('quotes are preserved when updated a TextNode value (double quote)', function () {
       let template = `<div class="lol"></div>`;
 


### PR DESCRIPTION
It appears glimmer/syntax strips out any newline characters from `<textarea>` children. This doesn't happen for other types of tags like `<div>` for example.