### PR TITLE
Expose the original contents on the plugin's `env`.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,9 @@ function print(ast) {
 }
 
 function transform(template, plugin) {
-  let ast;
+  let ast, contents;
   if (typeof template === 'string') {
+    contents = template;
     ast = parse(template);
   } else {
     // assume we were passed an ast
@@ -32,7 +33,7 @@ function transform(template, plugin) {
     traverse,
     Walker,
   };
-  let env = { syntax };
+  let env = { contents, syntax };
   let visitor = plugin(env);
   traverse(ast, visitor);
   return { ast, code: print(ast) };


### PR DESCRIPTION
This mirrors what ember-cli-htmlbars does and exposes the original raw template string to the underlying plugin.