### PR TITLE
Add failing test where attribute closes the quotations prematurely

### DIFF
--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -1222,6 +1222,24 @@ describe('ember-template-recast', function () {
       `);
     });
 
+    test('mutations in MustacheStatements retain whitespace in AttrNode', function () {
+      let template = stripIndent`
+        <div
+          class="
+            block
+            {{if this.foo "bar"}}
+          "
+        >
+          hello
+        </div>
+      `;
+
+      let ast = parse(template) as any;
+      ast.body[0].attributes[0].value.parts[1].params[1].value = 'bar';
+
+      expect(print(ast)).toEqual(template);
+    });
+
     test('quotes are preserved when updated a TextNode value (double quote)', function () {
       let template = `<div class="lol"></div>`;
 


### PR DESCRIPTION
When an attribute contains newlines, a mutation to a `MustacheStatement` inside of it will cause printing the AST to prematurely close the quotations, causing invalid markup.

Example,

```hbs
<div
  class="
    block
    {{if this.foo "bar"}}
  "
>
  hello
</div>
```

when parsed, mutated and printed will produce

```hbs
<div
  class=""
    block
    {{if this.foo "bar"}}
  "
>
  hello
</div>
```