### PR TITLE
Allow passing `filePath` to `transform`.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -87,15 +87,167 @@ describe('ember-template-recast', function () {
   });
 
   describe('transform', () => {
+    describe('legacy arguments', () => {
+      test('basic traversal', function () {
+        let template = '{{foo-bar bar=foo}}';
+        let paths: string[] = [];
+        transform(template, function () {
+          return {
+            PathExpression(node: AST.PathExpression) {
+              paths.push(node.original);
+            },
+          };
+        });
+
+        expect(paths).toEqual(['foo-bar', 'foo']);
+      });
+
+      test('can handle comment append before html node case', function () {
+        let template = '<table></table>';
+        let seen = new Set();
+
+        const result = transform(template, function ({ syntax }: any) {
+          const b = syntax.builders;
+
+          return {
+            ElementNode(node: AST.ElementNode) {
+              if (node.tag === 'table' && !seen.has(node)) {
+                seen.add(node);
+
+                return [
+                  b.mustacheComment(' template-lint-disable no-table-tag '),
+                  b.text('\n'),
+                  node,
+                ];
+              }
+              return node;
+            },
+          };
+        });
+
+        expect(result.code).toEqual(
+          ['{{!-- template-lint-disable no-table-tag --}}', '<table></table>'].join('\n')
+        );
+      });
+
+      test('can handle comment append between html + newline', function () {
+        let template = ['\n', '<table>', '<tbody></tbody>', '</table>'].join('\n');
+        let seen = new Set();
+
+        const result = transform(template, function ({ syntax }) {
+          const b = syntax.builders;
+
+          return {
+            ElementNode(node) {
+              if (node.tag === 'table' && !seen.has(node)) {
+                seen.add(node);
+
+                return [
+                  b.mustacheComment(' template-lint-disable no-table-tag '),
+                  b.text('\n'),
+                  node,
+                ];
+              }
+              return node;
+            },
+          };
+        });
+
+        expect(result.code).toEqual(
+          [
+            '\n',
+            '{{!-- template-lint-disable no-table-tag --}}',
+            '<table>',
+            '<tbody></tbody>',
+            '</table>',
+          ].join('\n')
+        );
+      });
+
+      test('can accept an AST', function () {
+        let template = '{{foo-bar bar=foo}}';
+        let paths: string[] = [];
+        let ast = parse(template);
+        transform(ast, function () {
+          return {
+            PathExpression(node) {
+              paths.push(node.original);
+            },
+          };
+        });
+
+        expect(paths).toEqual(['foo-bar', 'foo']);
+      });
+
+      test('returns code and ast', function () {
+        let template = '{{foo-bar}}';
+        let paths = [];
+        let { ast, code } = transform(template, function () {
+          return {
+            PathExpression(node) {
+              paths.push(node.original);
+            },
+          };
+        });
+
+        expect(ast).toBeTruthy();
+        expect(code).toBeTruthy();
+      });
+
+      test('replacement', function () {
+        let template = '{{foo-bar bar=foo}}';
+        let { code } = transform(template, (env) => {
+          let { builders: b } = env.syntax;
+          return {
+            MustacheStatement() {
+              return b.mustache(b.path('wat-wat'));
+            },
+          };
+        });
+
+        expect(code).toEqual('{{wat-wat}}');
+      });
+
+      test('removing the only hash pair on MustacheStatement', function () {
+        let template = '{{foo-bar hello="world"}}';
+        let { code } = transform(template, () => {
+          return {
+            MustacheStatement(ast) {
+              ast.hash.pairs.pop();
+            },
+          };
+        });
+
+        expect(code).toEqual('{{foo-bar}}');
+      });
+
+      test('pushing new item on to empty hash pair on MustacheStatement works', function () {
+        let template = '{{foo-bar}}{{#baz}}Hello!{{/baz}}';
+        let { code } = transform(template, (env) => {
+          let { builders: b } = env.syntax;
+          return {
+            MustacheStatement(ast) {
+              ast.hash.pairs.push(b.pair('hello', b.string('world')));
+            },
+          };
+        });
+
+        expect(code).toEqual('{{foo-bar hello="world"}}{{#baz}}Hello!{{/baz}}');
+      });
+    });
+
     test('basic traversal', function () {
       let template = '{{foo-bar bar=foo}}';
       let paths: string[] = [];
-      transform(template, function () {
-        return {
-          PathExpression(node: AST.PathExpression) {
-            paths.push(node.original);
-          },
-        };
+      transform({
+        template,
+        plugin() {
+          return {
+            PathExpression(node: AST.PathExpression) {
+              paths.push(node.original);
+            },
+          };
+        },
       });
 
       expect(paths).toEqual(['foo-bar', 'foo']);
@@ -105,23 +257,26 @@ describe('ember-template-recast', function () {
       let template = '<table></table>';
       let seen = new Set();
 
-      const result = transform(template, function ({ syntax }: any) {
-        const b = syntax.builders;
+      const result = transform({
+        template,
+        plugin({ syntax }: any) {
+          const b = syntax.builders;
 
-        return {
-          ElementNode(node: AST.ElementNode) {
-            if (node.tag === 'table' && !seen.has(node)) {
-              seen.add(node);
+          return {
+            ElementNode(node: AST.ElementNode) {
+              if (node.tag === 'table' && !seen.has(node)) {
+                seen.add(node);
 
-              return [
-                b.mustacheComment(' template-lint-disable no-table-tag '),
-                b.text('\n'),
-                node,
-              ];
-            }
-            return node;
-          },
-        };
+                return [
+                  b.mustacheComment(' template-lint-disable no-table-tag '),
+                  b.text('\n'),
+                  node,
+                ];
+              }
+              return node;
+            },
+          };
+        },
       });
 
       expect(result.code).toEqual(
@@ -133,23 +288,26 @@ describe('ember-template-recast', function () {
       let template = ['\n', '<table>', '<tbody></tbody>', '</table>'].join('\n');
       let seen = new Set();
 
-      const result = transform(template, function ({ syntax }) {
-        const b = syntax.builders;
+      const result = transform({
+        template,
+        plugin({ syntax }) {
+          const b = syntax.builders;
 
-        return {
-          ElementNode(node) {
-            if (node.tag === 'table' && !seen.has(node)) {
-              seen.add(node);
+          return {
+            ElementNode(node) {
+              if (node.tag === 'table' && !seen.has(node)) {
+                seen.add(node);
 
-              return [
-                b.mustacheComment(' template-lint-disable no-table-tag '),
-                b.text('\n'),
-                node,
-              ];
-            }
-            return node;
-          },
-        };
+                return [
+                  b.mustacheComment(' template-lint-disable no-table-tag '),
+                  b.text('\n'),
+                  node,
+                ];
+              }
+              return node;
+            },
+          };
+        },
       });
 
       expect(result.code).toEqual(
@@ -167,12 +325,15 @@ describe('ember-template-recast', function () {
       let template = '{{foo-bar bar=foo}}';
       let paths: string[] = [];
       let ast = parse(template);
-      transform(ast, function () {
-        return {
-          PathExpression(node) {
-            paths.push(node.original);
-          },
-        };
+      transform({
+        template: ast,
+        plugin() {
+          return {
+            PathExpression(node) {
+              paths.push(node.original);
+            },
+          };
+        },
       });
 
       expect(paths).toEqual(['foo-bar', 'foo']);
@@ -181,12 +342,15 @@ describe('ember-template-recast', function () {
     test('returns code and ast', function () {
       let template = '{{foo-bar}}';
       let paths = [];
-      let { ast, code } = transform(template, function () {
-        return {
-          PathExpression(node) {
-            paths.push(node.original);
-          },
-        };
+      let { ast, code } = transform({
+        template,
+        plugin() {
+          return {
+            PathExpression(node) {
+              paths.push(node.original);
+            },
+          };
+        },
       });
 
       expect(ast).toBeTruthy();
@@ -195,13 +359,16 @@ describe('ember-template-recast', function () {
 
     test('replacement', function () {
       let template = '{{foo-bar bar=foo}}';
-      let { code } = transform(template, (env) => {
-        let { builders: b } = env.syntax;
-        return {
-          MustacheStatement() {
-            return b.mustache(b.path('wat-wat'));
-          },
-        };
+      let { code } = transform({
+        template,
+        plugin(env) {
+          let { builders: b } = env.syntax;
+          return {
+            MustacheStatement() {
+              return b.mustache(b.path('wat-wat'));
+            },
+          };
+        },
       });
 
       expect(code).toEqual('{{wat-wat}}');
@@ -209,12 +376,15 @@ describe('ember-template-recast', function () {
 
     test('removing the only hash pair on MustacheStatement', function () {
       let template = '{{foo-bar hello="world"}}';
-      let { code } = transform(template, () => {
-        return {
-          MustacheStatement(ast) {
-            ast.hash.pairs.pop();
-          },
-        };
+      let { code } = transform({
+        template,
+        plugin() {
+          return {
+            MustacheStatement(ast) {
+              ast.hash.pairs.pop();
+            },
+          };
+        },
       });
 
       expect(code).toEqual('{{foo-bar}}');
@@ -222,13 +392,16 @@ describe('ember-template-recast', function () {
 
     test('pushing new item on to empty hash pair on MustacheStatement works', function () {
       let template = '{{foo-bar}}{{#baz}}Hello!{{/baz}}';
-      let { code } = transform(template, (env) => {
-        let { builders: b } = env.syntax;
-        return {
-          MustacheStatement(ast) {
-            ast.hash.pairs.push(b.pair('hello', b.string('world')));
-          },
-        };
+      let { code } = transform({
+        template,
+        plugin(env) {
+          let { builders: b } = env.syntax;
+          return {
+            MustacheStatement(ast) {
+              ast.hash.pairs.push(b.pair('hello', b.string('world')));
+            },
+          };
+        },
       });
 
       expect(code).toEqual('{{foo-bar hello="world"}}{{#baz}}Hello!{{/baz}}');
@@ -238,16 +411,21 @@ describe('ember-template-recast', function () {
   test('Build string from escaped string', function () {
     let template = '{{foo-bar placeholder="Choose a \\"thing\\"..."}}';
 
-    let { code } = transform(template, (env) => ({
-      MustacheStatement(node) {
-        let { builders: b } = env.syntax;
+    let { code } = transform({
+      template,
+      plugin(env) {
+        return {
+          MustacheStatement(node) {
+            let { builders: b } = env.syntax;
 
-        let value = node.hash.pairs[0].value as AST.StringLiteral;
-        let pair = b.pair('p1', b.string(value.original));
+            let value = node.hash.pairs[0].value as AST.StringLiteral;
+            let pair = b.pair('p1', b.string(value.original));
 
-        node.hash.pairs.push(pair);
+            node.hash.pairs.push(pair);
+          },
+        };
       },
-    }));
+    });
 
     expect(code).toEqual(
       '{{foo-bar placeholder="Choose a \\"thing\\"..." p1="Choose a \\"thing\\"..."}}'


### PR DESCRIPTION
This modifies the `transform` function to have a new signature:

```ts
export interface TransformOptions {
  /**
    The template to transform (either as a string or a pre-parsed AST.Template).
  */
  template: string | AST.Template;

  /**
    The plugin to use for transformation.
  */
  plugin: TransformPluginBuilder;

  /**
    The path (relative to the current working directory) to the file being transformed.

    This is useful when a given transform need to have differing behavior based on the
    location of the file (e.g. a component template should be modified differently than
    a route template).
  */
  filePath?: string;
}
export interface TransformResult {
  ast: AST.Template;
  code: string;
}
export function transform(options: TransformOptions): TransformResult;
```

This was done fully backwards compatibly.
