### PR TITLE
Refactor command line transform API to match JS API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ output === `
 />
 `; // is true!
 ```
+## Command Line Usage
+
+ember-template-recast comes with a binary for running a transform across multiple
+files, similar to jscodeshift.
+
+```
+npx ember-template-recast directory/of/templates -t transform.js
+```
+
+Example transform plugin:
+
+```js
+module.exports = (env) => {
+  let { builders: b } = env.syntax;
+
+  return {
+    MustacheStatement() {
+      return b.mustache(b.path('wat-wat'));
+    },
+  };
+};
+```
 
 ## APIs
 
@@ -129,34 +151,6 @@ let { code } = transform({
 });
 
 console.log(code); // => {{wat-wat}}
-```
-
-## Command Line Usage
-
-ember-template-recast comes with a binary for running a transform across multiple
-files, similar to jscodeshift.
-
-```
-npm install -g ember-template-recast
-ember-template-recast directory/of/templates -t transform.js
-```
-
-Example transform plugin:
-
-```js
-module.exports = function({ source, path }, { parse, visit }) {
-  const ast = parse(source);
-
-  return visit(ast, env => {
-    let { builders: b } = env.syntax;
-
-    return {
-      MustacheStatement() {
-        return b.mustache(b.path('wat-wat'));
-      },
-    };
-  });
-};
 ```
 
 ## SemVer Policy

--- a/src/bin.test.ts
+++ b/src/bin.test.ts
@@ -17,18 +17,14 @@ function run(args: string[], cwd: string) {
 }
 
 const transform = `
-module.exports = function ({ source }, { parse, visit }) {
-  const ast = parse(source);
+module.exports = (env) => {
+  let { builders: b } = env.syntax;
 
-  return visit(ast, (env) => {
-    let { builders: b } = env.syntax;
-
-    return {
-      MustacheStatement() {
-        return b.mustache(b.path('wat-wat'));
-      },
-    };
-  });
+  return {
+    MustacheStatement() {
+      return b.mustache(b.path('wat-wat'));
+    },
+  };
 };
 `;
 


### PR DESCRIPTION
Simplifies the `npx ember-template-recast --transform some/path.js **/*.hbs` syntax so that it matches the same syntax as a plugin that you would pass to `transform`.

---

From:

```js
module.exports = function ({ source }, { parse, visit }) {
  const ast = parse(source);
  return visit(ast, (env) => {
    let { builders: b } = env.syntax;

    return {
      MustacheStatement() {
        return b.mustache(b.path('wat-wat'));
      },
    };
  });
};
```

To:

```js
module.exports = (env) => {
  let { builders: b } = env.syntax;

  return {
    MustacheStatement() {
      return b.mustache(b.path('wat-wat'));
    },
  };
};
```
