### PR TITLE
Remove macOS from CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         node: ['10', '12', '14', '15']
-        os: [ubuntu, windows, macOS]
+        os: [ubuntu, windows]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Testing on macOS has been unstable (though actually usage on macOS has
been perfectly fine).

Removing from CI as I don't think testing macOS specifically on its own
provides much value.
