### PR TITLE
Ability to get env without transform call

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ let { code } = transform({
 console.log(code); // => {{wat-wat}}
 ```
 
+
+
+### envForTransformPlugin
+
+Used to get `TransformPluginEnv` object from template or transform options without plugin invocation;
+
+```ts
+envForTransformPlugin(templateOrOptions: string | AST.Template | TransformOptions): TransformPluginEnv
+```
+
 ## SemVer Policy
 
 Due to usage of TypeScript and bundling external APIs this project has somewhat

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,11 @@
-import { builders, parse, print, transform } from './index';
+import {
+  builders,
+  parse,
+  print,
+  transform,
+  envForTransformPlugin,
+  TransformPluginBuilder,
+} from './index';
 import type { AST } from '@glimmer/syntax';
 import { stripIndent } from 'common-tags';
 
@@ -84,6 +91,48 @@ describe('ember-template-recast', function () {
     element.children.push(builders.text('derp&nbsp;'));
 
     expect(print(ast)).toEqual(stripIndent`<div>&nbsp;derp&nbsp;</div>`);
+  });
+
+  describe('envForTransformPlugin', () => {
+    test('it return correct TransformPluginEnv instance if there is no plugin argument', function () {
+      let env = envForTransformPlugin('{{foo-bar}}');
+
+      expect(env.filePath).toEqual(undefined);
+      expect(env.contents).toEqual('{{foo-bar}}');
+      expect(env.parseOptions.srcName).toEqual(undefined);
+    });
+
+    test('it return correct TransformPluginEnv instance with  plugin argument', function () {
+      let env = envForTransformPlugin({
+        plugin: ((() => {}) as unknown) as TransformPluginBuilder,
+        template: '{{foo-bar}}',
+        filePath: 'foo',
+      });
+
+      expect(env.contents).toEqual('{{foo-bar}}');
+      expect(env.filePath).toEqual('foo');
+      expect(env.parseOptions.srcName).toEqual('foo');
+    });
+
+    test('it return correct TransformPluginEnv instance with ast as argument', function () {
+      let env = envForTransformPlugin(parse('{{foo-bar}}'));
+
+      expect(env.contents).toEqual('{{foo-bar}}');
+      expect(env.filePath).toEqual(undefined);
+      expect(env.parseOptions.srcName).toEqual(undefined);
+    });
+
+    test('it return correct TransformPluginEnv instance with ast as argument template param', function () {
+      let env = envForTransformPlugin({
+        plugin: ((() => {}) as unknown) as TransformPluginBuilder,
+        template: parse('{{foo-bar}}'),
+        filePath: 'foo',
+      });
+
+      expect(env.contents).toEqual('{{foo-bar}}');
+      expect(env.filePath).toEqual('foo');
+      expect(env.parseOptions.srcName).toEqual('foo');
+    });
   });
 
   describe('transform', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,21 +84,26 @@ export interface TransformOptions {
 }
 
 export function envForTransformPlugin(
-  templateOrOptions: string | AST.Template | TransformOptions,
-  plugin?: TransformPluginBuilder
+  templateOrOptions: string | AST.Template | TransformOptions
 ): TransformPluginEnv {
   let contents: string;
-  let filePath: undefined | string;
+  let filePath: undefined | string = undefined;
   let template: string | AST.Template;
 
-  if (plugin === undefined) {
-    let options = templateOrOptions as TransformOptions;
-    // TransformOptions invocation style
-    template = options.template;
-    filePath = options.filePath;
+  if (typeof templateOrOptions !== 'string') {
+    if ('plugin' in templateOrOptions) {
+      let options = templateOrOptions as TransformOptions;
+      if ('template' in options) {
+        template = options.template;
+      }
+      if ('filePath' in options) {
+        filePath = options.filePath;
+      }
+    } else {
+      template = templateOrOptions as AST.Template;
+    }
   } else {
-    template = templateOrOptions as AST.Template;
-    filePath = undefined;
+    template = templateOrOptions as string;
   }
 
   let getAST = (): AST.Template => {
@@ -151,7 +156,7 @@ export function transform(
   let ast: AST.Template;
   let template: string | AST.Template;
 
-  const env = envForTransformPlugin(templateOrOptions, plugin);
+  const env = envForTransformPlugin(templateOrOptions);
 
   if (plugin === undefined) {
     let options = templateOrOptions as TransformOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,6 @@ export function envForTransformPlugin(
     let options = templateOrOptions as TransformOptions;
     // TransformOptions invocation style
     template = options.template;
-    plugin = options.plugin;
     filePath = options.filePath;
   } else {
     template = templateOrOptions as AST.Template;

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,21 +141,25 @@ export function transform(
   plugin?: TransformPluginBuilder
 ): TransformResult {
   let ast: AST.Template;
+  let template: string | AST.Template;
 
   const env = envForTransformPlugin(templateOrOptions, plugin);
 
   if (plugin === undefined) {
     let options = templateOrOptions as TransformOptions;
     plugin = options.plugin;
+    template = options.template;
+  } else {
+    template = templateOrOptions as string;
   }
 
   const visitor = plugin(env);
 
-  if (typeof templateOrOptions === 'string') {
-    ast = parse(templateOrOptions as string);
+  if (typeof template === 'string') {
+    ast = parse(template as string);
   } else {
     // assume we were passed an ast
-    ast = templateOrOptions as AST.Template;
+    ast = template as AST.Template;
   }
 
   traverse(ast, visitor);


### PR DESCRIPTION
related MR: https://github.com/ember-template-lint/ember-template-lint/pull/1697

TLDR: now we have ability to get transform environment valuse without plugin call

Bonus: some lazyness added, should improve performance, especiall for template-lint

// cc @rwjblue 