### PR TITLE
Add failing test to show extra quoting being applied to a concat statement

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -374,6 +374,22 @@ describe('ember-template-recast', function () {
       expect(code).toEqual('{{wat-wat}}');
     });
 
+    test('replacing a @class with a class', function () {
+      let template = '<div @class="{{if foo "bar"}} baz" />';
+      let { code } = transform({
+        template,
+        plugin() {
+          return {
+            AttrNode(node) {
+              node.name = 'class';
+            },
+          };
+        },
+      });
+
+      expect(code).toEqual('<div class="{{if foo "bar"}} baz" />');
+    });
+
     test('removing the only hash pair on MustacheStatement', function () {
       let template = '{{foo-bar hello="world"}}';
       let { code } = transform({


### PR DESCRIPTION
I encountered this issue when writing a linter to replace all instances of `@class` with `class` in our codebase. This can happen when we try to mass migrate curly brace components to angle brackets and inadvertently convert html attributes to args.