### PR TITLE
test(#587): reproduction of double quotes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -431,4 +431,21 @@ describe('ember-template-recast', function () {
       '{{foo-bar placeholder="Choose a \\"thing\\"..." p1="Choose a \\"thing\\"..."}}'
     );
   });
+
+  test('stack trace does not exceed', function () {
+    let b = builders;
+    let template = '<div @class="{{if foo "bar"}} baz" />';
+    let { code } = transform({
+      template,
+      plugin() {
+        return {
+          AttrNode(node) {
+            node.value = b.concat([b.text('foobar')]);
+          },
+        };
+      },
+    });
+
+    expect(code).toEqual('<div @class="foobar" />');
+  });
 });

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -1265,6 +1265,14 @@ describe('ember-template-recast', function () {
       ast.body[0].attributes[0].name = 'class';
       expect(print(ast)).toEqual('<div class="{{if foo "bar"}} baz" />');
     });
+
+    test('quotes are preserved when updating an AttrNode value', function () {
+      let template = '<div class="{{if foo "bar"}} baz" />';
+
+      let ast = parse(template) as any;
+      ast.body[0].attributes[0].value = builders.concat([builders.text('foobar')]);
+      expect(print(ast)).toEqual('<div class="foobar" />');
+    });
   });
 
   describe('HashPair', function () {


### PR DESCRIPTION
- Single text element inside concat produces an extra pair of quotes