### PR TITLE
test(#586): can reuse previous concat parts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,14 +18,7 @@ export function print(ast: AST.Node): string {
 
   // TODO: write a test for this case
   if (parseResult === undefined) {
-    return glimmerPrint(ast, {
-      entityEncoding: 'raw',
-      override: (ast) => {
-        if (NODE_INFO.has(ast)) {
-          return print(ast);
-        }
-      },
-    });
+    return glimmerPrint(ast, { entityEncoding: 'raw' });
   }
 
   return parseResult.print();

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -25,18 +25,6 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`<img src="{{this.something}}">`);
     });
 
-    test('can reuse previous concat parts', function () {
-      let template = `<img src="foo {{bar}} baz">`;
-      let original = parse(template);
-      let element = original.body[0] as AST.ElementNode;
-      let attribute = element.attributes[0] as AST.AttrNode;
-      let concat = attribute.value as AST.ConcatStatement;
-
-      let ast = builders.concat([concat.parts[0], concat.parts[1]]);
-
-      expect(print(ast)).toEqual(`<img src="foo {{bar}}">`);
-    });
-
     test('can print parsed element', function () {
       let template = `<img src="foo {{bar}} baz">`;
       let original = parse(template);

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -25,12 +25,13 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`<img src="{{this.something}}">`);
     });
 
-    test('can print parsed element', function () {
-      let template = `<img src="foo {{bar}} baz">`;
+    test('reusing another template part to build a new template', function () {
+      let template = `foo`;
       let original = parse(template);
-      let element = original.body[0] as AST.ElementNode;
+      let text = original.body[0] as AST.TextNode;
+      let ast = builders.template([text]);
 
-      expect(print(element)).toEqual(`<img src="foo {{bar}}">`);
+      expect(print(ast)).toEqual(`foo`);
     });
 
     test('changing an element to a void element does not print closing tag', function () {

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -37,6 +37,14 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`<img src="foo {{bar}}">`);
     });
 
+    test('can print parsed element', function () {
+      let template = `<img src="foo {{bar}} baz">`;
+      let original = parse(template);
+      let element = original.body[0] as AST.ElementNode;
+
+      expect(print(element)).toEqual(`<img src="foo {{bar}}">`);
+    });
+
     test('changing an element to a void element does not print closing tag', function () {
       let template = `<div data-foo="{{something}}"></div>`;
 

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -25,6 +25,18 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`<img src="{{this.something}}">`);
     });
 
+    test('can reuse previous concat parts', function () {
+      let template = `<img src="foo {{bar}} baz">`;
+      let original = parse(template);
+      let element = original.body[0] as AST.ElementNode;
+      let attribute = element.attributes[0] as AST.AttrNode;
+      let concat = attribute.value as AST.ConcatStatement;
+
+      let ast = builders.concat([concat.parts[0], concat.parts[1]]);
+
+      expect(print(ast)).toEqual(`<img src="foo {{bar}}">`);
+    });
+
     test('changing an element to a void element does not print closing tag', function () {
       let template = `<div data-foo="{{something}}"></div>`;
 


### PR DESCRIPTION
- Test proving that when you reuse parts from previous concat statement in new concat statement you will get "Maximum callstack size exceeded"

Running this:

```
❯ yarn jest src/parse-result.test.ts -t 'can reuse previous concat parts'
```

Gives me:

```
  ● ember-template-recast › ElementNode › can reuse previous concat parts

    RangeError: Maximum call stack size exceeded

      19 |   // TODO: write a test for this case
      20 |   if (parseResult === undefined) {
    > 21 |     return glimmerPrint(ast, {
         |                         ^
      22 |       entityEncoding: 'raw',
      23 |       override: (ast) => {
      24 |         if (NODE_INFO.has(ast)) {

      at print (src/index.ts:21:25)
      at Object.override (src/index.ts:25:18)
      at Printer.print (node_modules/@glimmer/syntax/packages/@glimmer/syntax/lib/generation/printer.ts:539:20)
      at Object.build (node_modules/@glimmer/syntax/packages/@glimmer/syntax/lib/generation/print.ts:13:10)
      at print (src/index.ts:21:12)
      at Object.override (src/index.ts:25:18)
      at Printer.print (node_modules/@glimmer/syntax/packages/@glimmer/syntax/lib/generation/printer.ts:539:20)
      at Object.build (node_modules/@glimmer/syntax/packages/@glimmer/syntax/lib/generation/print.ts:13:10)
      at print (src/index.ts:21:12)
      at Object.override (src/index.ts:25:18)
```