### PR TITLE
Allow updating `quoteType` and `isValueless` of AttrNodes, and `quoteType` of StringLiterals

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ export interface TransformPluginBuilder {
 ```
 
 The list of known builders on the `env.syntax.builders` are [found
-here](https://github.com/glimmerjs/glimmer-vm/blob/v0.62.4/packages/%40glimmer/syntax/lib/builders.ts#L547-L578).
+here](https://github.com/glimmerjs/glimmer-vm/blob/v0.62.4/packages/%40glimmer/syntax/lib/builders.ts#L547-L578),
+although there are a few small extensions related to formatting
+[in `custom-nodes.ts`](src/custom-nodes.ts)
 
 Example:
 ```js

--- a/src/custom-nodes.ts
+++ b/src/custom-nodes.ts
@@ -1,0 +1,52 @@
+import { AST, builders as _builders } from '@glimmer/syntax';
+
+export type QuoteType = '"' | "'";
+export interface AnnotatedAttrNode extends AST.AttrNode {
+  // like `<input disabled>` or `<div ...attributes>`
+  isValueless?: boolean;
+  // TextNode values can use single, double, or no quotes
+  // `type=input` vs `type='input'` vs `type="input"`
+  // ConcatStatement values can use single or double quotes
+  // `class='thing {{get this classNames}}'` vs `class="thing {{get this classNames}}"`
+  // MustacheStatements never use quotes
+  quoteType?: QuoteType | null;
+}
+
+export interface AnnotatedStringLiteral extends AST.StringLiteral {
+  quoteType?: QuoteType;
+}
+
+// The glimmer printer doesn't have any formatting suppport.
+// It always uses double quotes, and won't print attrs without
+// a value. To choose quote types or omit the value, we've
+// gotta do it ourselves.
+export function useCustomPrinter(node: AST.BaseNode): boolean {
+  switch (node.type) {
+    case 'StringLiteral':
+      return !!(node as AnnotatedStringLiteral).quoteType;
+      break;
+    case 'AttrNode':
+      {
+        const n = node as AnnotatedAttrNode;
+        return !!n.isValueless || n.quoteType !== undefined;
+      }
+      break;
+    default:
+      return false;
+  }
+}
+
+type ReplaceReturnType<F extends (...a: any) => any, NewReturn> = (
+  ...a: Parameters<F>
+) => NewReturn;
+
+// Update glimmer's builders to return our annotated types,
+// so that tests and users can specify formatting properties
+// on constructed nodes
+type _Builders = typeof _builders;
+export interface Builders extends Omit<_Builders, 'attr' | 'string'> {
+  attr: ReplaceReturnType<typeof _builders.attr, AnnotatedAttrNode>;
+  string: ReplaceReturnType<typeof _builders.string, AnnotatedStringLiteral>;
+}
+
+export const builders = _builders as Builders;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-import { traverse, builders, Walker, print as glimmerPrint } from '@glimmer/syntax';
+import { traverse, Walker, print as glimmerPrint } from '@glimmer/syntax';
 import type { AST, NodeVisitor } from '@glimmer/syntax';
 import ParseResult, { NodeInfo } from './parse-result';
+import { builders } from './custom-nodes';
 
 const PARSE_RESULT_FOR = new WeakMap<AST.Node, ParseResult>();
 const NODE_INFO = new WeakMap<AST.Node, NodeInfo>();
@@ -142,5 +143,6 @@ export function transform(
 
 export type { AST, NodeVisitor } from '@glimmer/syntax';
 
-export { builders, traverse } from '@glimmer/syntax';
+export { traverse } from '@glimmer/syntax';
+export { builders } from './custom-nodes';
 export { sourceForLoc } from './utils';


### PR DESCRIPTION
Enhancement: allow setting `quoteType` of AttrNodes during transform.

This enables adding a fixer for the `quotes` rule to `ember-template-lint`