### PR TITLE
Fix #371 (attribute closes the quotations prematurely)

### DIFF
--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -1224,6 +1224,24 @@ describe('ember-template-recast', function () {
       `);
     });
 
+    test('mutations in MustacheStatements retain whitespace in AttrNode', function () {
+      let template = stripIndent`
+        <div
+          class="
+            block
+            {{if this.foo "bar"}}
+          "
+        >
+          hello
+        </div>
+      `;
+
+      let ast = parse(template) as any;
+      ast.body[0].attributes[0].value.parts[1].params[1].value = 'bar';
+
+      expect(print(ast)).toEqual(template);
+    });
+
     test('quotes are preserved when updated a TextNode value (double quote)', function () {
       let template = `<div class="lol"></div>`;
 

--- a/src/parse-result.ts
+++ b/src/parse-result.ts
@@ -56,7 +56,6 @@ function fixASTIssues(sourceLines: any, ast: any) {
       (node as any).quoteType = quote ? quote : null;
     },
     TextNode(node, path) {
-      const source = sourceForLoc(sourceLines, node.loc);
       if (path.parentNode === null) {
         throw new Error(
           'ember-template-recast: Error while sanitizing input AST: found TextNode with no parentNode'
@@ -65,6 +64,7 @@ function fixASTIssues(sourceLines: any, ast: any) {
 
       switch (path.parentNode.type) {
         case 'AttrNode': {
+          const source = sourceForLoc(sourceLines, node.loc);
           if (
             node.chars.length > 0 &&
             ((source.startsWith(`'`) && source.endsWith(`'`)) ||

--- a/src/parse-result.ts
+++ b/src/parse-result.ts
@@ -76,13 +76,15 @@ function fixASTIssues(sourceLines: any, ast: any) {
           break;
         }
         case 'ConcatStatement': {
-          // TODO: manually working around https://github.com/glimmerjs/glimmer-vm/pull/954
           const parent = path.parentNode as AST.ConcatStatement;
           const isFirstPart = parent.parts.indexOf(node) === 0;
 
+          const { start, end } = node.loc;
           if (isFirstPart && node.loc.start.column > path.parentNode.loc.start.column + 1) {
-            const { start, end } = node.loc;
+            // TODO: manually working around https://github.com/glimmerjs/glimmer-vm/pull/954
             node.loc = builders.loc(start.line, start.column - 1, end.line, end.column);
+          } else if (isFirstPart && node.chars.charAt(0) === '\n') {
+            node.loc = builders.loc(start.line, start.column + 1, end.line, end.column);
           }
         }
       }


### PR DESCRIPTION
## A fix for #371 

I couldn't write to #371, so I'm opening this new PR to fix the failing test. Thanks a lot @kamal for the report and the failing test. It was very helpful!


## The Bug
As @kamal wrote in the description:

> When an attribute contains newlines, a mutation to a `MustacheStatement` inside of it will cause printing the AST to prematurely close the quotations, causing invalid markup.
> 
> Example,
> 
> ```hbs
> <div
>   class="
>     block
>     {{if this.foo "bar"}}
>   "
> >
>   hello
> </div>
> ```
> 
> when parsed, mutated and printed will produce
> 
> ```hbs
> <div
>   class=""
>     block
>     {{if this.foo "bar"}}
>   "
> >
>   hello
> </div>
> ```