### PR TITLE
Fix infinite recursion when printing sub-nodes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,26 +3,22 @@ import type { ASTv1 as AST, NodeVisitor } from '@glimmer/syntax';
 import ParseResult, { NodeInfo } from './parse-result';
 import { builders } from './custom-nodes';
 
-const PARSE_RESULT_FOR = new WeakMap<AST.Node, ParseResult>();
 const NODE_INFO = new WeakMap<AST.Node, NodeInfo>();
 
 export function parse(template: string): AST.Template {
-  const result = new ParseResult(template, NODE_INFO);
-
-  PARSE_RESULT_FOR.set(result.ast, result);
-
-  return result.ast;
+  return new ParseResult(template, NODE_INFO).ast;
 }
 
 export function print(ast: AST.Node): string {
-  const parseResult = PARSE_RESULT_FOR.get(ast);
-
-  // TODO: write a test for this case
-  if (parseResult === undefined) {
-    return glimmerPrint(ast, { entityEncoding: 'raw' });
-  }
-
-  return parseResult.print();
+  return glimmerPrint(ast, {
+    entityEncoding: 'raw',
+    override: (ast) => {
+      let info = NODE_INFO.get(ast);
+      if (info) {
+        return info.parse_result.print(ast);
+      }
+    },
+  });
 }
 
 export interface Syntax {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,14 +19,7 @@ export function print(ast: AST.Node): string {
 
   // TODO: write a test for this case
   if (parseResult === undefined) {
-    return glimmerPrint(ast, {
-      entityEncoding: 'raw',
-      override: (ast) => {
-        if (NODE_INFO.has(ast)) {
-          return print(ast);
-        }
-      },
-    });
+    return glimmerPrint(ast, { entityEncoding: 'raw' });
   }
 
   return parseResult.print();

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -27,18 +27,6 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`<img src="{{this.something}}">`);
     });
 
-    test('can reuse previous concat parts', function () {
-      let template = `<img src="foo {{bar}} baz">`;
-      let original = parse(template);
-      let element = original.body[0] as AST.ElementNode;
-      let attribute = element.attributes[0] as AST.AttrNode;
-      let concat = attribute.value as AST.ConcatStatement;
-
-      let ast = builders.concat([concat.parts[0], concat.parts[1]]);
-
-      expect(print(ast)).toEqual(`<img src="foo {{bar}}">`);
-    });
-
     test('can print parsed element', function () {
       let template = `<img src="foo {{bar}} baz">`;
       let original = parse(template);

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -27,12 +27,13 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`<img src="{{this.something}}">`);
     });
 
-    test('can print parsed element', function () {
-      let template = `<img src="foo {{bar}} baz">`;
+    test('reusing another template part to build a new template', function () {
+      let template = `foo`;
       let original = parse(template);
-      let element = original.body[0] as AST.ElementNode;
+      let text = original.body[0] as AST.TextNode;
+      let ast = builders.template([text]);
 
-      expect(print(element)).toEqual(`<img src="foo {{bar}}">`);
+      expect(print(ast)).toEqual(`foo`);
     });
 
     test('changing an element to a void element does not print closing tag', function () {

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -39,6 +39,14 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`<img src="foo {{bar}}">`);
     });
 
+    test('can print parsed element', function () {
+      let template = `<img src="foo {{bar}} baz">`;
+      let original = parse(template);
+      let element = original.body[0] as AST.ElementNode;
+
+      expect(print(element)).toEqual(`<img src="foo {{bar}}">`);
+    });
+
     test('changing an element to a void element does not print closing tag', function () {
       let template = `<div data-foo="{{something}}"></div>`;
 

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -36,6 +36,23 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`foo`);
     });
 
+    test('wrapping a parsed node (which uses custom formatting) with a raw node', function () {
+      // Ensuring fix for GH#586
+      // (infinite recursion when printing custom nodes containing parsed nodes)
+      // plays nicely with custom printing from GH#653
+      // (specifying quoteType on custom nodes, adds a printing override)
+      let template = `<Foo @class='a {{b}} c' />`;
+      let original = parse(template);
+
+      let raw_wrapping_ast = builders.template([
+        builders.element('div', {
+          children: original.body,
+        }),
+      ]);
+
+      expect(print(raw_wrapping_ast)).toEqual(`<div><Foo @class='a {{b}} c' /></div>`);
+    });
+
     test('changing an element to a void element does not print closing tag', function () {
       let template = `<div data-foo="{{something}}"></div>`;
 

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -27,6 +27,18 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual(`<img src="{{this.something}}">`);
     });
 
+    test('can reuse previous concat parts', function () {
+      let template = `<img src="foo {{bar}} baz">`;
+      let original = parse(template);
+      let element = original.body[0] as AST.ElementNode;
+      let attribute = element.attributes[0] as AST.AttrNode;
+      let concat = attribute.value as AST.ConcatStatement;
+
+      let ast = builders.concat([concat.parts[0], concat.parts[1]]);
+
+      expect(print(ast)).toEqual(`<img src="foo {{bar}}">`);
+    });
+
     test('changing an element to a void element does not print closing tag', function () {
       let template = `<div data-foo="{{something}}"></div>`;
 

--- a/src/parse-result.ts
+++ b/src/parse-result.ts
@@ -115,6 +115,7 @@ export interface NodeInfo {
   node: AST.Node;
   original: AST.Node;
   source: string;
+  parse_result: ParseResult;
 
   hadHash?: boolean;
   hadParams?: boolean;
@@ -156,6 +157,7 @@ export default class ParseResult {
       node,
       original: JSON.parse(JSON.stringify(node)),
       source: this.sourceForLoc(node.loc),
+      parse_result: this,
     };
 
     this.nodeInfo.set(node, nodeInfo);


### PR DESCRIPTION
~Built starting from https://github.com/ember-template-lint/ember-template-recast/pull/653, so that should be merged first. For an easier code review, look at [the diff against that branch](https://github.com/courajs/ember-template-recast/pull/1)~
Fixes https://github.com/ember-template-lint/ember-template-recast/issues/586
Includes test from #586, with some expanded coverage and a different fix.