### PR TITLE
Confirm that a single text element inside a concat doesn't produces an extra pair of quotes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -431,4 +431,21 @@ describe('ember-template-recast', function () {
       '{{foo-bar placeholder="Choose a \\"thing\\"..." p1="Choose a \\"thing\\"..."}}'
     );
   });
+
+  test('can replace an `AttrNode`s value with a new `ConcatStatement`', function () {
+    let b = builders;
+    let template = '<div class="{{if foo "bar"}} baz" />';
+    let { code } = transform({
+      template,
+      plugin() {
+        return {
+          AttrNode(node) {
+            node.value = b.concat([b.text('foobar'), b.text('baz')]);
+          },
+        };
+      },
+    });
+
+    expect(code).toEqual('<div class="foobarbaz" />');
+  });
 });

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -1295,6 +1295,14 @@ describe('ember-template-recast', function () {
       expect(print(ast)).toEqual('<div class="{{if foo "bar"}} baz" />');
     });
 
+    test('quotes are preserved when updating an AttrNode value - issue #588', function () {
+      let template = '<div class="{{if foo "bar"}} baz" />';
+
+      let ast = parse(template) as any;
+      ast.body[0].attributes[0].value = builders.concat([builders.text('foobar')]);
+      expect(print(ast)).toEqual('<div class="foobar" />');
+    });
+
     test('TextNode quote types can be changed', function () {
       let template = '<div class=foo />';
       let ast = parse(template) as any;


### PR DESCRIPTION
@MichalBryxi for the sake of simplicity I have extracted in this PR the tests you added in https://github.com/ember-template-lint/ember-template-recast/pull/588.

It confirms that the recent enhancement landed by @courajs fixed https://github.com/ember-template-lint/ember-template-recast/issues/587. 🎉