### PR TITLE
Replace common-tags by @glimmer/util

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,12 @@
     "workerpool": "^6.1.5"
   },
   "devDependencies": {
-    "@types/common-tags": "^1.8.1",
+    "@glimmer/util": "^0.83.1",
     "@types/jest": "^27.0.2",
     "@types/workerpool": "^6.1.0",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "broccoli-test-helper": "^2.0.0",
-    "common-tags": "^1.8.0",
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-node": "^11.1.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { builders, parse, print, transform } from './index';
 import type { ASTv1 as AST } from '@glimmer/syntax';
-import { stripIndent } from 'common-tags';
+import { strip as stripIndent } from '@glimmer/util';
 
 describe('ember-template-recast', function () {
   test('basic parse + print (no modification)', function () {

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -1,6 +1,6 @@
 import { builders, parse, print, transform } from '.';
 import type { ASTv1 as AST } from '@glimmer/syntax';
-import { stripIndent } from 'common-tags';
+import { strip as stripIndent } from '@glimmer/util';
 
 describe('ember-template-recast', function () {
   describe('ElementNode', function () {

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -429,17 +429,15 @@ describe('"real life" smoke tests', function () {
         };
       });
 
-      expect(code).toEqual(stripIndent`
+      expect(code).toEqual(`        {{#if (a)}}
+  {{0}}
+
+{{/if}}
+
         {{#if (a)}}
-          {{0}}
+  {{1}}
 
-        {{/if}}
-
-        {{#if (a)}}
-          {{1}}
-
-        {{/if}}
-      `);
+{{/if}}`);
     });
 
     test('`if` branch containing whitespace controls', function () {
@@ -592,19 +590,17 @@ describe('"real life" smoke tests', function () {
         };
       });
 
-      expect(code).toEqual(stripIndent`
-        <br>
-        {{#if (a)}}
-          {{0}}
+      expect(code).toEqual(`<br>
+{{#if (a)}}
+  {{0}}
 
-        {{/if}}
-        <div></div>
-        {{#if (a)}}
-          {{1}}
+{{/if}}
+<div></div>
+{{#if (a)}}
+  {{1}}
 
-        {{/if}}
-        <hr>
-      `);
+{{/if}}
+<hr>`);
     });
   });
 

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -1,6 +1,6 @@
 import { parse, sourceForLoc, transform, builders, TransformPluginEnv } from '.';
 import type { ASTv1 as AST, NodeVisitor } from '@glimmer/syntax';
-import { stripIndent } from 'common-tags';
+import { strip as stripIndent } from '@glimmer/util';
 
 describe('"real life" smoke tests', function () {
   describe('line endings', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,6 +317,13 @@
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
+"@glimmer/interfaces@0.83.1":
+  version "0.83.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.83.1.tgz#fb16f5f683ddc55f130887b6141f58c0751350fe"
+  integrity sha512-rjAztghzX97v8I4rk3+NguM3XGYcFjc/GbJ8qrEj19KF2lUDoDBW1sB7f0tov3BD5HlrGXei/vOh4+DHfjeB5w==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
 "@glimmer/reference@^0.83.0":
   version "0.83.0"
   resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.83.0.tgz#496bea33cb7f9d5c1751fa1d918e4ebb845d8b60"
@@ -345,6 +352,15 @@
   dependencies:
     "@glimmer/env" "0.1.7"
     "@glimmer/interfaces" "0.83.0"
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/util@^0.83.1":
+  version "0.83.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.83.1.tgz#cc7511b03164d658cf6e3262fce5a0fcb82edceb"
+  integrity sha512-amvjtl9dvrkxsoitXAly9W5NUaLIE3A2J2tWhBWIL1Z6DOFotfX7ytIosOIcPhJLZCtiXPHzMutQRv0G/MSMsA==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "0.83.1"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/validator@0.83.0", "@glimmer/validator@^0.83.0":
@@ -855,11 +871,6 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
-"@types/common-tags@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@types/common-tags/-/common-tags-1.8.1.tgz#a5a49ca5ebbb58e0f8947f3ec98950c8970a68a9"
-  integrity sha512-20R/mDpKSPWdJs5TOpz3e7zqbeCNuMCPhV7Yndk9KU2Rbij2r5W4RzwDPkzC+2lzUqXYu9rFzTktCBnDjHuNQg==
 
 "@types/debug@^4.0.0":
   version "4.1.7"
@@ -1849,11 +1860,6 @@ commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
-
-common-tags@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
-  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
 
 component-emitter@^1.2.1:
   version "1.3.0"


### PR DESCRIPTION
The bump of common-tags from 1.8.0 to 1.8.1 (https://github.com/ember-template-lint/ember-template-recast/pull/683) isn't as smooth as expected. The CI fails and the test suite would need adjustements.

`commont-tags` is a full-featured package but we use it for only one function in the test suite: `stripIndent`.

I noticed that @glimmer/util ships a `strip` function that does the same thing. This function doesn't play well with multi-line blocks though. This is why I had to adjust two tests.