### PR TITLE
Replace common-tags by outdent

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,13 +45,11 @@
     "workerpool": "^6.1.5"
   },
   "devDependencies": {
-    "@types/common-tags": "^1.8.1",
     "@types/jest": "^27.0.2",
     "@types/workerpool": "^6.1.0",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "broccoli-test-helper": "^2.0.0",
-    "common-tags": "^1.8.0",
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-node": "^11.1.0",
@@ -59,6 +57,7 @@
     "execa": "^5.1.1",
     "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",
+    "outdent": "^0.8.0",
     "prettier": "^2.4.1",
     "release-it": "^14.11.6",
     "release-it-lerna-changelog": "^4.0.1",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { builders, parse, print, transform } from './index';
 import type { ASTv1 as AST } from '@glimmer/syntax';
-import { stripIndent } from 'common-tags';
+import stripIndent from 'outdent';
 
 describe('ember-template-recast', function () {
   test('basic parse + print (no modification)', function () {

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -797,7 +797,7 @@ describe('ember-template-recast', function () {
         builders.pair('hello', builders.string('world')),
       ]);
 
-      expect(print(ast)).toEqual(stripIndent`{{foo-bar\n  baz=(stuff hello="world")\n}}`);
+      expect(print(ast)).toEqual(`{{foo-bar\n  baz=(stuff hello="world")\n}}`);
     });
   });
 

--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -1,6 +1,6 @@
 import { builders, parse, print, transform } from '.';
 import type { ASTv1 as AST } from '@glimmer/syntax';
-import { stripIndent } from 'common-tags';
+import stripIndent from 'outdent';
 
 describe('ember-template-recast', function () {
   describe('ElementNode', function () {

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -1,6 +1,6 @@
 import { parse, sourceForLoc, transform, builders, TransformPluginEnv } from '.';
 import type { ASTv1 as AST, NodeVisitor } from '@glimmer/syntax';
-import { stripIndent } from 'common-tags';
+import stripIndent from 'outdent';
 
 describe('"real life" smoke tests', function () {
   describe('line endings', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -856,11 +856,6 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/common-tags@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@types/common-tags/-/common-tags-1.8.1.tgz#a5a49ca5ebbb58e0f8947f3ec98950c8970a68a9"
-  integrity sha512-20R/mDpKSPWdJs5TOpz3e7zqbeCNuMCPhV7Yndk9KU2Rbij2r5W4RzwDPkzC+2lzUqXYu9rFzTktCBnDjHuNQg==
-
 "@types/debug@^4.0.0":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -1849,11 +1844,6 @@ commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
-
-common-tags@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
-  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -5144,6 +5134,11 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+outdent@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.8.0.tgz#2ebc3e77bf49912543f1008100ff8e7f44428eb0"
+  integrity sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==
 
 p-cancelable@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
The `stripIndent` function published in [common-tags](https://github.com/zspecza/common-tags/) has some small changes that make the bump from 1.8.0 to 1.8.1 less straightforward than replacing it by outdent.

Implements feedback: https://github.com/ember-template-lint/ember-template-recast/pull/687#issuecomment-969114157