### PR TITLE
Update Typescript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "target": "es2019",
+    "lib": ["es2019", "dom"],
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Changes

- We now target Nodejs 12. So we can change the tsconfig.json's target to `es2019` (for reference, see:
https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-12)

- Add the `lib` field in tsconfig.json. As a result, we restrict build-in type declarations to `es2019` and `dom`. Adding these two groups seem to be the minimal requirement to add the `lib` field.

## Why do we need this change?

In a follow-up, we will add `es2020.string` to the `lib` field It will allow us to use String.matchAll which is also supported in Nodejs 12.