### PR TITLE
Fix parsing error when in-tag string content contains `>`

### DIFF
--- a/src/parse-result.test.ts
+++ b/src/parse-result.test.ts
@@ -1,4 +1,4 @@
-import { builders, parse, print, transform } from '.';
+import { builders, parse, print, transform, traverse } from '.';
 import type { ASTv1 as AST } from '@glimmer/syntax';
 import stripIndent from 'outdent';
 
@@ -548,6 +548,25 @@ describe('ember-template-recast', function () {
               some-other-thing={{haha}} foo-foo="wheee">
         </div>
       `);
+    });
+
+    test('issue can handle angle brackets in modifier argument values', function () {
+      let template = `
+        <Select
+          @placeholder={{do-something ">> Some Text Here"}}
+          @options={{this.items}}
+          as |item|
+        >
+          {{item.name}}
+        </Select>
+      `;
+      let ast = parse(template);
+      traverse(ast, {
+        ElementNode(node) {
+          node.tag = `${node.tag}`;
+        },
+      });
+      expect(print(ast)).toEqual(template);
     });
 
     test('issue 706', function () {

--- a/src/parse-result.ts
+++ b/src/parse-result.ts
@@ -513,7 +513,10 @@ export default class ParseResult {
               blockParamsEndIndex + 1
             );
 
-            const closeOpenIndex = nodeInfo.source.indexOf(selfClosing ? '/>' : '>');
+            // Match closing index after start of block params to avoid closing tag if /> or > encountered in string
+            const closeOpenIndex =
+              nodeInfo.source.substring(blockParamStartIndex).indexOf(selfClosing ? '/>' : '>') +
+              blockParamStartIndex;
             postBlockParamsWhitespace = nodeInfo.source.substring(
               blockParamsEndIndex + 1,
               closeOpenIndex


### PR DESCRIPTION
Resolves an issue where an `ElementNode` with block params can be prematurely terminated if a right angle bracket (`>`) is included in a string before the true closing bracket.

fixes #995